### PR TITLE
refactor(client): replace hardcoded API URLs with VITE_API_URL

### DIFF
--- a/client/src/auth/useWelcomeDiscount.js
+++ b/client/src/auth/useWelcomeDiscount.js
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef } from "react";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 export function useWelcomeDiscount(user) {
   const [showBanner, setShowBanner] = useState(false);

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -1,7 +1,7 @@
 // src/components/FitnessChatBot.jsx
 import { useState, useEffect, useRef } from "react";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const WELCOME = {
   role: "bot",

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API_BASE = import.meta.env.VITE_API_URL;
 
 const fmt = (n) =>
   new Intl.NumberFormat("en-IN", {

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -7,7 +7,7 @@ import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 export default function Checkout() {
   const navigate = useNavigate();

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -12,7 +12,7 @@ import WelcomeBanner from "../components/WelcomeBanner";
 import { useWelcomeDiscount } from "../auth/useWelcomeDiscount";
 import BMICalculator from "../components/BMICalculator";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const CATEGORIES = [
   { name: "All", value: "all" },

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -5,7 +5,7 @@ import { auth } from "../auth/firebase";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 const RAZORPAY_KEY = import.meta.env.VITE_RAZORPAY_KEY_ID;
 
 function useRazorpayScript() {

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -6,7 +6,7 @@ import { getAuthHeaders } from "../utils/getAuthHeaders";
 import { fmt } from "../utils/formatters";
 import CartDrawer from "../components/CartDrawer";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const Stars = ({ rating = 0, size = "sm" }) => {
   const full = Math.floor(rating || 0);


### PR DESCRIPTION
## 📋 What does this PR do?
Removes the hardcoded fallback `|| "http://localhost:5000"` from 7 files 
in client/src, so all API calls exclusively use the `VITE_API_URL` 
environment variable. This makes the codebase environment-agnostic and 
prevents accidental connections to localhost in production.

Files changed:
- src/auth/useWelcomeDiscount.js
- src/components/FitnessChatBot.jsx
- src/pages/AdminDashboard.jsx
- src/pages/Checkout.jsx
- src/pages/HomePage.jsx
- src/pages/PaymentPage.jsx
- src/pages/ProductPage.jsx

## 🔗 Related Issue
As noted in the README: "Some client files still use the hardcoded 
http://localhost:5000. Standardize everything on VITE_API_URL. 
This is a great first contribution!"

## 🧪 How was this tested?
Used VS Code global search to verify no instances of the hardcoded 
`http://localhost:5000` fallback remain in client/src after the changes.

## 📸 Screenshots (if UI changes)
No UI changes — this is a refactor only.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys