### PR TITLE
fix: add size guard, timestamps, and redact sensitive fields in logger

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,18 @@
+const SENSITIVE_FIELDS = ['token', 'password'];
+
+function redact(body) {
+  const sanitized = { ...body };
+  for (const field of SENSITIVE_FIELDS) {
+    if (sanitized[field]) sanitized[field] = '[REDACTED]';
+  }
+  return sanitized;
+}
+
+const timestamp = new Date().toISOString();
+const bodyStr = JSON.stringify(req.body);
+
+if (bodyStr.length < 1000) {
+  console.log(`[${timestamp}] ${req.method} ${req.url}`, redact(req.body));
+} else {
+  console.log(`[${timestamp}] ${req.method} ${req.url} [body too large to log]`);
+}


### PR DESCRIPTION
- Added size guard for request body logging
- Added ISO timestamps to logs
- Redacted sensitive fields (token, password)