### PR TITLE
feat(client): extend PropTypes validation to additional components

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
         "firebase": "^12.9.0",
+        "prop-types": "^15.8.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
@@ -3567,7 +3568,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3938,6 +3938,18 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4008,6 +4020,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -4147,6 +4168,23 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/protobufjs": {
       "version": "7.5.4",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
     "firebase": "^12.9.0",
+    "prop-types": "^15.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -1,6 +1,7 @@
 // src/components/AdminNavbar.jsx
 import { useNavigate } from "react-router-dom";
 import { signOut } from "firebase/auth";
+import PropTypes from "prop-types";
 import { auth } from "../auth/firebase";
 import { useAuth } from "../auth/useAuth";
 
@@ -142,3 +143,9 @@ export default function AdminNavbar({ range, setRange, menuOpen, setMenuOpen }) 
     </div>
   );
 }
+AdminNavbar.propTypes = {
+  range: PropTypes.string,
+  setRange: PropTypes.func,
+  menuOpen: PropTypes.bool,
+  setMenuOpen: PropTypes.func,
+};

--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import { useAuth } from "../auth/useAuth";
 
 const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
@@ -12,3 +13,7 @@ export default function AdminRoute({ children }) {
   if (user.uid !== ADMIN_UID) return <Navigate to="/home" replace />;
   return children;
 }
+
+AdminRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -1,5 +1,6 @@
 // src/components/CartDrawer.jsx
 import { useEffect } from "react";
+import PropTypes from "prop-types";
 import { fmt } from "../utils/formatters";
 import { Link } from "react-router-dom";
 
@@ -226,5 +227,24 @@ function CartDrawer({
     </>
   );
 }
+
+CartDrawer.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  cart: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      name: PropTypes.string,
+      brand: PropTypes.string,
+      price: PropTypes.number,
+      image: PropTypes.string,
+      qty: PropTypes.number,
+    })
+  ).isRequired,
+  cartCount: PropTypes.number,
+  cartTotal: PropTypes.number,
+  updateQty: PropTypes.func.isRequired,
+  removeFromCart: PropTypes.func.isRequired,
+};
 
 export default CartDrawer;

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,6 +1,7 @@
 // src/components/Navbar.jsx
 import { useNavigate } from "react-router-dom";
 import { signOut } from "firebase/auth";
+import PropTypes from "prop-types";
 import { auth } from "../auth/firebase";
 import { useAuth } from "../auth/useAuth";
 
@@ -231,3 +232,13 @@ export default function Navbar({
     </nav>
   );
 }
+Navbar.propTypes = {
+  variant: PropTypes.oneOf(["landing", "home"]),
+  navOpaque: PropTypes.bool,
+  onSearchToggle: PropTypes.func,
+  cartCount: PropTypes.number,
+  onCartOpen: PropTypes.func,
+  menuOpen: PropTypes.bool,
+  setMenuOpen: PropTypes.func,
+  onSignOut: PropTypes.func,
+};

--- a/client/src/components/NonAdminRoute.jsx
+++ b/client/src/components/NonAdminRoute.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Navigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import { useAuth } from "../auth/useAuth";
 
 const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
@@ -12,3 +13,7 @@ export default function NonAdminRoute({ children }) {
   if (user && user.uid === ADMIN_UID) return <Navigate to="/admin/dashboard" replace />;
   return children;
 }
+
+NonAdminRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/client/src/components/WelcomeBanner.jsx
+++ b/client/src/components/WelcomeBanner.jsx
@@ -1,5 +1,6 @@
 // src/components/WelcomeBanner.jsx
 import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 
 export default function WelcomeBanner({ onDismiss }) {
   const [visible, setVisible] = useState(false);
@@ -64,3 +65,6 @@ export default function WelcomeBanner({ onDismiss }) {
     </div>
   );
 }
+WelcomeBanner.propTypes = {
+  onDismiss: PropTypes.func,
+};

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -1,6 +1,7 @@
 // src/pages/Checkout.jsx
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { fmt } from "../utils/formatters";
@@ -261,6 +262,12 @@ function PageShell({ children, menuOpen, setMenuOpen }) {
   );
 }
 
+PageShell.propTypes = {
+  children: PropTypes.node.isRequired,
+  menuOpen: PropTypes.bool,
+  setMenuOpen: PropTypes.func,
+};
+
 function Spinner() {
   return (
     <div className="flex items-center justify-center h-64">
@@ -278,6 +285,10 @@ function ErrorMsg({ msg }) {
   );
 }
 
+ErrorMsg.propTypes = {
+  msg: PropTypes.string.isRequired,
+};
+
 function EmptyCart({ navigate }) {
   return (
     <div className="flex flex-col items-center justify-center h-64 text-center gap-4 px-4">
@@ -293,3 +304,7 @@ function EmptyCart({ navigate }) {
     </div>
   );
 }
+
+EmptyCart.propTypes = {
+  navigate: PropTypes.func.isRequired,
+};

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -1,6 +1,7 @@
 // src/pages/ProductPage.jsx
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import { auth } from "../auth/firebase";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import { fmt } from "../utils/formatters";
@@ -43,6 +44,11 @@ const Stars = ({ rating = 0, size = "sm" }) => {
       ))}
     </span>
   );
+};
+
+Stars.propTypes = {
+  rating: PropTypes.number,
+  size: PropTypes.oneOf(["sm", "lg"]),
 };
 
 const FEATURE_MAP = {
@@ -772,3 +778,8 @@ function Shell({ children, cartCount = 0, onCartOpen }) {
     </div>
   );
 }
+Shell.propTypes = {
+  children: PropTypes.node.isRequired,
+  cartCount: PropTypes.number,
+  onCartOpen: PropTypes.func,
+};


### PR DESCRIPTION
## 📋 What does this PR do?
Extends PropTypes validation to all components beyond Navbar and CartDrawer.
Adds prop-types to package.json and covers:
- Navbar, CartDrawer, AdminNavbar, AdminRoute, NonAdminRoute, WelcomeBanner (components/)
- Stars, Shell (ProductPage), PageShell, ErrorMsg, EmptyCart (pages/)

## 🔗 Related Issue
Closes #110

## 🧪 How was this tested?
- Verified prop-types is installed in client/package.json
- Reviewed all components for incoming props
- Added PropTypes definitions matching actual prop usage

## 📸 Screenshots (if UI changes)
No UI changes

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys