### PR TITLE
fix: validate productId and quantity inputs in cart API endpoints

### DIFF
--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -53,10 +53,15 @@ router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
   try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
-    if (productId == null || quantity == null) return res.status(400).json({ error: 'productId and quantity required' });
+    
+    if (productId === undefined || typeof productId !== 'number') {
+      return res.status(400).json({ error: 'productId must be a number' });
+}
 
-    const qty = Number(quantity);
-    if (Number.isNaN(qty) || qty <= 0) return res.status(400).json({ error: 'quantity must be a positive number' });
+    if (!Number.isInteger(quantity) || quantity <= 0) {
+      return res.status(400).json({ error: 'quantity must be a positive integer' });
+}
+    const qty = quantity;
 
     const product = await Product.findOne({ productId: Number(productId) });
     if (!product) return res.status(404).json({ error: 'Product not found' });
@@ -95,10 +100,15 @@ router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
   try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
-    if (productId == null || quantity == null) return res.status(400).json({ error: 'productId and quantity required' });
 
-    const qty = Number(quantity);
-    if (Number.isNaN(qty) || qty <= 0) return res.status(400).json({ error: 'quantity must be a positive number' });
+    if (productId === undefined || typeof productId !== 'number') {
+      return res.status(400).json({ error: 'productId must be a number' });
+}
+
+    if (!Number.isInteger(quantity) || quantity <= 0) {
+      return res.status(400).json({ error: 'quantity must be a positive integer' });
+}
+    const qty = quantity;
 
     const cart = await Cart.findOne({ userId });
     if (!cart) return res.status(404).json({ error: 'Cart not found' });


### PR DESCRIPTION
### Summary
Added validation for productId and quantity in cart API endpoints (/add and /remove).

### Changes
- Ensured productId is present and a number
- Ensured quantity is a positive integer greater than 0
- Return 400 Bad Request for invalid inputs

### Testing
- quantity: -1 → 400
- quantity: "two" → 400
- missing productId → 400
- valid inputs work as expected

### Notes
Validation is applied before business logic to prevent incorrect stock calculations and DB errors.