### PR TITLE
Fix: replace hardcoded API URLs with VITE_API_URL

### DIFF
--- a/client/src/auth/useWelcomeDiscount.js
+++ b/client/src/auth/useWelcomeDiscount.js
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef } from "react";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 export function useWelcomeDiscount(user) {
   const [showBanner, setShowBanner] = useState(false);

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -1,7 +1,7 @@
 // src/components/FitnessChatBot.jsx
 import { useState, useEffect, useRef } from "react";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const WELCOME = {
   role: "bot",

--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessCenterDetail from "./FitnessCenterDetail";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 function Stars({ rating = 0 }) {
   const full = Math.floor(rating || 0);

--- a/client/src/components/ReportBugButton.jsx
+++ b/client/src/components/ReportBugButton.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useAuth } from '../auth/useAuth';
 
-const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+const API = import.meta.env.VITE_API_URL;
 
 export default function ReportBugButton() {
   const { user } = useAuth();

--- a/client/src/pages/AdminBugs.jsx
+++ b/client/src/pages/AdminBugs.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import AdminNavbar from '../components/AdminNavbar';
 import { useAuth } from '../auth/useAuth';
 
-const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+const API = import.meta.env.VITE_API_URL;
 
 const SEGMENT_STYLES = {
   open: "bg-stone-900 text-white",

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const fmt = (n) =>
   new Intl.NumberFormat("en-IN", {

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -7,7 +7,7 @@ import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 export default function Checkout() {
   const navigate = useNavigate();

--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -42,7 +42,7 @@ export default function ExercisePage() {
     setImageErrors(new Set());
 
     try {
-      const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:5000";
+      const API = import.meta.env.VITE_API_URL;
       const response = await fetch(`${apiUrl}/api/exercises/${bodyPart}`);
 
       if (!response.ok) {

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -14,7 +14,7 @@ import BMICalculator from "../components/BMICalculator";
 import CalorieCalculator from "../components/CalorieCalculator";
 import NearbyFitnessCenters from "../components/NearbyFitnessCenters";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const CATEGORIES = [
   { name: "All", value: "all" },

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import { auth } from "../auth/firebase";
 import { fmt } from "../utils/formatters";
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+
 
 // ── Static data ────────────────────────────────────────────────────────────
 // Real repo stats from GitHub API
@@ -108,6 +108,7 @@ export default function LandingPage() {
   const [loadingProducts, setLoadingProducts] = useState(true);
   const [backendError, setBackendError] = useState(false);
 
+  const API = import.meta.env.VITE_API_URL;
   useEffect(() => {
     document.title = "FitMart - Fitness & Nutrition Store";
   }, []);

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -5,7 +5,7 @@ import { auth } from "../auth/firebase";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 const RAZORPAY_KEY = import.meta.env.VITE_RAZORPAY_KEY_ID;
 
 function useRazorpayScript() {

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -6,7 +6,7 @@ import { getAuthHeaders } from "../utils/getAuthHeaders";
 import { fmt } from "../utils/formatters";
 import CartDrawer from "../components/CartDrawer";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 const Stars = ({ rating = 0, size = "sm" }) => {
   const full = Math.floor(rating || 0);

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -6,7 +6,7 @@ import { onAuthStateChanged } from "firebase/auth";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const API = import.meta.env.VITE_API_URL;
 
 function Toast({ message, onClose }) {
   useEffect(() => {


### PR DESCRIPTION
Replaced hardcoded localhost API calls with VITE_API_URL in client/src files.

Tested locally — frontend works with environment-based API configuration.