### PR TITLE
fix: add request size limit and sanitize error responses

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,9 +6,13 @@ const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
 const app = express();
 const port = process.env.PORT || 5000;
-const allowedOrigin = process.env.ALLOWED_ORIGIN || "http://localhost:5173,http://127.0.0.1:5173";
-const allowedOrigins = allowedOrigin.split(",").map((s) => s.trim()).filter(Boolean);
-const isDev = process.env.NODE_ENV === 'development';
+const allowedOrigin =
+  process.env.ALLOWED_ORIGIN || "http://localhost:5173,http://127.0.0.1:5173";
+const allowedOrigins = allowedOrigin
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+const isDev = process.env.NODE_ENV === "development";
 
 // Display missing variables at server startup. Only require truly critical vars
 // to avoid failing entirely in environments where optional services (Razorpay)
@@ -32,14 +36,22 @@ const missingCritical = CRITICAL_ENV_VARS.filter((v) => !process.env[v]);
 const missingOptional = OPTIONAL_ENV_VARS.filter((v) => !process.env[v]);
 
 if (missingCritical.length > 0) {
-  console.error(`❌ Missing critical environment variables: ${missingCritical.join(", ")}`);
-  console.error("Server cannot start without these. Please set them in your environment.");
+  console.error(
+    `❌ Missing critical environment variables: ${missingCritical.join(", ")}`,
+  );
+  console.error(
+    "Server cannot start without these. Please set them in your environment.",
+  );
   process.exit(1);
 }
 
 if (missingOptional.length > 0) {
-  console.warn(`⚠️ Missing optional environment variables: ${missingOptional.join(", ")}`);
-  console.warn("Continuing startup; some optional functionality may be disabled.");
+  console.warn(
+    `⚠️ Missing optional environment variables: ${missingOptional.join(", ")}`,
+  );
+  console.warn(
+    "Continuing startup; some optional functionality may be disabled.",
+  );
 }
 
 // ── Middleware ──────────────────────────────────────────────────────────────
@@ -65,12 +77,15 @@ app.use(
     origin: function (origin, callback) {
       // Allow requests with no origin (like mobile apps or curl requests)
       if (!origin) {
-        console.log('[CORS] Allowing request with no origin');
+        console.log("[CORS] Allowing request with no origin");
         return callback(null, true);
       }
 
       // In development, be more permissive
-      if (isDev && origin.includes('localhost') || origin.includes('127.0.0.1')) {
+      if (
+        (isDev && origin.includes("localhost")) ||
+        origin.includes("127.0.0.1")
+      ) {
         console.log(`[CORS] Allowing local development origin: ${origin}`);
         return callback(null, true);
       }
@@ -81,7 +96,9 @@ app.use(
         return callback(null, true);
       }
 
-      console.error(`[CORS] Rejecting origin: ${origin}. Allowed origins: ${allowedOrigins.join(', ')}`);
+      console.error(
+        `[CORS] Rejecting origin: ${origin}. Allowed origins: ${allowedOrigins.join(", ")}`,
+      );
       return callback(new Error("Not allowed by CORS"));
     },
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
@@ -91,13 +108,13 @@ app.use(
 );
 
 app.use(helmet());
-app.use(express.json());
+app.use(express.json({ limit: "10kb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
-app.disable('etag');
+app.disable("etag");
 
 // Ensure API responses are not served from client caches (avoid 304 from conditional requests)
-app.use('/api', (req, res, next) => {
-  res.setHeader('Cache-Control', 'no-store');
+app.use("/api", (req, res, next) => {
+  res.setHeader("Cache-Control", "no-store");
   next();
 });
 app.use("/api", apiLimiter);
@@ -112,13 +129,13 @@ const logger = require("./middleware/logger");
 app.use(logger);
 //Dashboard route needs logger to parse query params for logging
 
-const dashboardRoutes = require('./routes/dashboard');
+const dashboardRoutes = require("./routes/dashboard");
 
 // ── API routes (prefixed) ───────────────────────────────────────────────────
 app.use("/api/products", require("./routes/products"));
 app.use("/api/cart", require("./routes/cart"));
 app.use("/api/orders", require("./routes/orders"));
-app.use('/api/dashboard', dashboardRoutes);
+app.use("/api/dashboard", dashboardRoutes);
 app.use("/api/reports", require("./routes/reports"));
 app.use("/api/chat", require("./routes/chat"));
 app.use("/api/user", require("./routes/user"));
@@ -143,8 +160,8 @@ app.use((err, req, res, next) => {
   if (err instanceof SyntaxError && err.status === 400 && "body" in err) {
     return res.status(400).json({ error: "Invalid JSON payload" });
   }
-  console.error("Unhandled error:", err);
-  res.status(500).json({ error: "Internal server error" });
+  console.error("Unhandled error:", err.message);
+  res.status(500).json({ error: "Something went wrong" });
 });
 
 app.listen(port, () => {

--- a/server/index.js
+++ b/server/index.js
@@ -109,6 +109,7 @@ app.use(
 
 app.use(helmet());
 app.use(express.json({ limit: "10kb" }));
+app.use(express.urlencoded({ extended: true, limit: "10kb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
 app.disable("etag");
 


### PR DESCRIPTION
## 📋 What does this PR do?
Adds basic security improvements to the server by limiting request payload size and sanitizing error responses.

## 🔗 Related Issue
Closes #32

## 🧪 How was this tested?
* Ran the server locally after applying changes
* Verified that the server starts successfully
* Confirmed that middleware changes do not break existing functionality
* MongoDB connection is not configured locally (using dummy URI), which does not affect the middleware changes

## ✨ Changes
* Added 10kb limit to JSON request body using express.json
* Added 10kb limit to URL-encoded request body using express.urlencoded
* Improved global error handling to avoid exposing internal error details

## ✅ Checklist
* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys
