### PR TITLE
Fix: Reduce sensitive body logging and add timestamps in logger middleware

### DIFF
--- a/server/middleware/logger.js
+++ b/server/middleware/logger.js
@@ -1,11 +1,29 @@
 // server/middleware/logger.js
 
-// Function to get base route only
+//  Sensitive fields to redact
+const SENSITIVE_FIELDS = ['token', 'password', 'secret', 'apiKey', 'authorization'];
+
+//  Function to redact sensitive fields (recursive)
+function redactSensitiveFields(obj) {
+  if (typeof obj !== 'object' || obj === null) return obj;
+
+  const newObj = Array.isArray(obj) ? [...obj] : { ...obj };
+
+  for (const key in newObj) {
+    if (SENSITIVE_FIELDS.includes(key.toLowerCase())) {
+      newObj[key] = '[REDACTED]';
+    } else if (typeof newObj[key] === 'object') {
+      newObj[key] = redactSensitiveFields(newObj[key]);
+    }
+  }
+
+  return newObj;
+}
+
+// 🔹 Function to get base route only
 const getBaseRoute = (url) => {
-  // Match patterns like /api/cart, /api/products, /api/orders
   const match = url.match(/^(\/api\/(?:cart|products|orders))/);
   if (match) {
-    // If it's a cart route with additional path, append the action
     if (url.includes('/cart/') && !url.match(/^\/api\/cart\/?$/)) {
       if (url.includes('/add')) return '/api/cart/add';
       if (url.includes('/remove')) return '/api/cart/remove';
@@ -15,44 +33,51 @@ const getBaseRoute = (url) => {
   return url;
 };
 
-// Simple logger with colors (without timestamps)
+// 🔹 Logger middleware (with timestamp, size guard, redaction)
 const logger = (req, res, next) => {
   const start = Date.now();
 
-  // Log when the request completes
   res.on('finish', () => {
     const duration = Date.now() - start;
     const status = res.statusCode;
+    const timestamp = new Date().toISOString();
 
-    // Get the simplified route
     const simplifiedUrl = getBaseRoute(req.originalUrl);
 
-    // Color coding for HTTP methods
+    //  Color coding for HTTP methods
     const methodColor = {
-      'GET': '\x1b[34m',    // Blue
-      'POST': '\x1b[32m',   // Green
-      'PUT': '\x1b[33m',    // Yellow
-      'DELETE': '\x1b[31m', // Red
-      'PATCH': '\x1b[35m',  // Magenta
-    }[req.method] || '\x1b[0m'; // Default
+      'GET': '\x1b[34m',
+      'POST': '\x1b[32m',
+      'PUT': '\x1b[33m',
+      'DELETE': '\x1b[31m',
+      'PATCH': '\x1b[35m',
+    }[req.method] || '\x1b[0m';
 
     // Color coding for status codes
-    const statusColor = status >= 500 ? '\x1b[31m' : // Red
-      status >= 400 ? '\x1b[33m' : // Yellow
-        status >= 300 ? '\x1b[36m' : // Cyan
-          status >= 200 ? '\x1b[32m' : // Green
-            '\x1b[0m'; // Default
+    const statusColor = status >= 500 ? '\x1b[31m' :
+      status >= 400 ? '\x1b[33m' :
+        status >= 300 ? '\x1b[36m' :
+          status >= 200 ? '\x1b[32m' :
+            '\x1b[0m';
 
-    // Format the log message without timestamp
+    // Main log with timestamp
     console.log(
+      `[${timestamp}] ` +
       `${methodColor}${req.method.padEnd(6)}\x1b[0m ` +
       `${statusColor}${status}\x1b[0m ` +
       `${simplifiedUrl}`
     );
 
-    // Log request body for non-GET requests (optional)
+    // Body logging with size guard + redaction
     if (req.method !== 'GET' && Object.keys(req.body || {}).length > 0) {
-      console.log(`   Body: ${JSON.stringify(req.body)}`);
+      const bodyStr = JSON.stringify(req.body);
+
+      if (bodyStr.length < 1000) {
+        const safeBody = redactSensitiveFields(req.body);
+        console.log(`[${timestamp}] Body: ${JSON.stringify(safeBody)}`);
+      } else {
+        console.log(`[${timestamp}] Body: [body too large to log]`);
+      }
     }
   });
 


### PR DESCRIPTION
###  Changes Made
- Added ISO timestamp to all log lines
- Implemented size guard (logs only if body < 1000 chars)
- Redacted sensitive fields like token and password

###  Security Improvements
- Prevents logging sensitive user data
- Avoids large unreadable logs

###  Testing
- Verified small request bodies are logged correctly
- Verified large bodies are skipped
- Verified sensitive fields are replaced with [REDACTED]