### PR TITLE
fix: reduce sensitive body logging and add timestamps in logger middl…

### DIFF
--- a/server/middleware/logger.js
+++ b/server/middleware/logger.js
@@ -1,11 +1,38 @@
 // server/middleware/logger.js
 
-// Function to get base route only
+// ── Configuration ───────────────────────────────────────────────────────────
+
+/** Maximum body length (in characters) before the body is considered too large to log. */
+const MAX_BODY_LENGTH = 1000;
+
+/**
+ * Set of request-body field names whose values should never appear in logs.
+ * Matching is case-insensitive.
+ */
+const SENSITIVE_FIELDS = new Set([
+  'password',
+  'token',
+  'secret',
+  'authorization',
+  'creditcard',
+  'credit_card',
+  'cardnumber',
+  'card_number',
+  'cvv',
+  'ssn',
+  'razorpay_signature',
+  'razorpay_payment_id',
+]);
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Return a simplified base-route string so that logs are easier to scan.
+ * e.g. `/api/cart/add?foo=1` → `/api/cart/add`
+ */
 const getBaseRoute = (url) => {
-  // Match patterns like /api/cart, /api/products, /api/orders
   const match = url.match(/^(\/api\/(?:cart|products|orders))/);
   if (match) {
-    // If it's a cart route with additional path, append the action
     if (url.includes('/cart/') && !url.match(/^\/api\/cart\/?$/)) {
       if (url.includes('/add')) return '/api/cart/add';
       if (url.includes('/remove')) return '/api/cart/remove';
@@ -15,44 +42,87 @@ const getBaseRoute = (url) => {
   return url;
 };
 
-// Simple logger with colors (without timestamps)
+/**
+ * Deep-clone a plain object and replace the values of any keys whose names
+ * appear in SENSITIVE_FIELDS with a `[REDACTED]` placeholder.
+ *
+ * @param {Record<string,any>} obj – the original body object
+ * @returns {Record<string,any>}    – a sanitised copy safe for logging
+ */
+const redactSensitiveFields = (obj) => {
+  if (typeof obj !== 'object' || obj === null) return obj;
+
+  const redacted = Array.isArray(obj) ? [] : {};
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (SENSITIVE_FIELDS.has(key.toLowerCase())) {
+      redacted[key] = '[REDACTED]';
+    } else if (typeof value === 'object' && value !== null) {
+      redacted[key] = redactSensitiveFields(value);
+    } else {
+      redacted[key] = value;
+    }
+  }
+
+  return redacted;
+};
+
+// ── Middleware ───────────────────────────────────────────────────────────────
+
+/**
+ * Express middleware that logs every request with:
+ * - ISO-8601 timestamp
+ * - Colour-coded HTTP method
+ * - Colour-coded status code
+ * - Simplified route
+ * - Response time in ms
+ * - Redacted request body (for non-GET requests, if body is under the size limit)
+ */
 const logger = (req, res, next) => {
   const start = Date.now();
 
-  // Log when the request completes
   res.on('finish', () => {
     const duration = Date.now() - start;
     const status = res.statusCode;
+    const timestamp = new Date().toISOString();
 
-    // Get the simplified route
     const simplifiedUrl = getBaseRoute(req.originalUrl);
 
-    // Color coding for HTTP methods
+    // Colour coding for HTTP methods
     const methodColor = {
       'GET': '\x1b[34m',    // Blue
       'POST': '\x1b[32m',   // Green
       'PUT': '\x1b[33m',    // Yellow
       'DELETE': '\x1b[31m', // Red
       'PATCH': '\x1b[35m',  // Magenta
-    }[req.method] || '\x1b[0m'; // Default
+    }[req.method] || '\x1b[0m';
 
-    // Color coding for status codes
-    const statusColor = status >= 500 ? '\x1b[31m' : // Red
-      status >= 400 ? '\x1b[33m' : // Yellow
-        status >= 300 ? '\x1b[36m' : // Cyan
-          status >= 200 ? '\x1b[32m' : // Green
-            '\x1b[0m'; // Default
+    // Colour coding for status codes
+    const statusColor = status >= 500 ? '\x1b[31m' :
+      status >= 400 ? '\x1b[33m' :
+        status >= 300 ? '\x1b[36m' :
+          status >= 200 ? '\x1b[32m' :
+            '\x1b[0m';
 
-    // Format the log message without timestamp
+    // Main log line — now prefixed with an ISO timestamp and includes duration
     console.log(
+      `\x1b[90m[${timestamp}]\x1b[0m ` +
       `${methodColor}${req.method.padEnd(6)}\x1b[0m ` +
       `${statusColor}${status}\x1b[0m ` +
-      `${simplifiedUrl}`
+      `${simplifiedUrl} ` +
+      `\x1b[90m${duration}ms\x1b[0m`
     );
 
-    // Log request body for non-GET requests (optional)
-    if (req.method !== 'GET' && Object.keys(req.body || {}).length > 0) {
-      console.log(`   Body: ${JSON.stringify(req.body)}`);
+    // Log request body for non-GET requests (with size guard and redaction)
+    if (req.method !== 'GET' && req.body && Object.keys(req.body).length > 0) {
+      const bodyStr = JSON.stringify(req.body);
+
+      if (bodyStr.length < MAX_BODY_LENGTH) {
+        const safeBody = redactSensitiveFields(req.body);
+        console.log(`   Body: ${JSON.stringify(safeBody)}`);
+      } else {
+        console.log(`   Body: [body too large to log – ${bodyStr.length} chars]`);
+      }
     }
   });
 


### PR DESCRIPTION
## 📋 What does this PR do?
Fixes the logger middleware (`server/middleware/logger.js`) to:
- **Add ISO-8601 timestamps** to every log line for traceability
- **Add a 1000-char size guard** to prevent logging oversized request bodies
- **Redact sensitive fields** (`password`, `token`, `secret`, `razorpay_signature`, `razorpay_payment_id`, `cvv`, `ssn`, etc.) before logging
- **Add response duration** (`Nms`) to each log line for performance observability
## 🔗 Related Issue
Closes #58
## 🧪 How was this tested?
1. **Syntax validation**: Ran `node -c server/middleware/logger.js` — passes with no errors
2. **Timestamp verification**: Started the server with `npm start`, sent requests via browser/Postman, confirmed every log line is prefixed with `[2026-04-19T01:07:18.123Z]` format
3. **Size guard**: Sent a POST request with a body over 1000 chars — confirmed log shows `[body too large to log – N chars]` instead of the full body
4. **Sensitive field redaction**: Sent a POST request with `{"token": "abc123", "password": "secret", "quantity": 2}` — confirmed log shows `{"token":"[REDACTED]","password":"[REDACTED]","quantity":2}`
5. **Normal bodies**: Sent a normal small POST request — confirmed body is still logged correctly (with sensitive fields redacted)
6. **GET requests**: Confirmed GET requests do not log any body, same as before
7. **No breaking changes**: The module exports the same middleware function — no API changes
### Before / After
**Before:**
POST 200 /api/cart/add Body: {"userId":"abc","token":"eyJhbG...","quantity":2}

**After:**
[2026-04-19T01:07:18.123Z] POST 200 /api/cart/add 12ms Body: {"userId":"abc","token":"[REDACTED]","quantity":2}

## 📸 Screenshots (if UI changes)
No UI changes — this is a backend-only middleware fix.
## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys