### PR TITLE
fix: resolve broken modal layout in NearbyFitnessCenters (#192)

### DIFF
--- a/client/src/components/FitnessCenterDetail.jsx
+++ b/client/src/components/FitnessCenterDetail.jsx
@@ -22,7 +22,7 @@ export default function FitnessCenterDetail({ center }) {
   if (!center) return null;
 
   return (
-    <div className="bg-white border border-stone-200 rounded-2xl p-6 flex flex-col md:flex-row gap-6 hover:shadow-lg transition-all duration-300">
+    <div className="bg-white rounded-2xl p-6 flex flex-col md:flex-row gap-6">
       <div className="w-full md:w-1/3 rounded-xl overflow-hidden bg-stone-100 flex items-center justify-center">
         {center.imageUrl ? (
           <img src={center.imageUrl} alt={center.name} className="w-full h-48 object-cover" onError={e => e.currentTarget.style.display = 'none'} />

--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessCenterDetail from "./FitnessCenterDetail";
 
@@ -49,6 +50,7 @@ export default function NearbyFitnessCenters({ visible = true }) {
   }, [filter]);
 
   return (
+    <>
     <section className={`fade-in d1 ${visible ? "show" : ""}`}>
       <div className="mb-4 sm:mb-6 flex items-center justify-between">
         <div>
@@ -113,33 +115,36 @@ export default function NearbyFitnessCenters({ visible = true }) {
           ))
         )}
       </div>
-      {/* Modal */}
-      {modalOpen && selected && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-10">
-          <div
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-            onClick={() => setModalOpen(false)}
-            aria-hidden
-          />
-
-          <div className="relative w-full max-w-3xl mx-auto">
-            <div className="p-4">
-              <button
-                type="button"
-                onClick={() => setModalOpen(false)}
-                className="absolute -top-2 -right-2 bg-white rounded-full p-2 border border-stone-200 shadow-sm text-stone-600"
-                aria-label="Close"
-              >
-                ×
-              </button>
-              <div className="bg-white rounded-2xl p-6">
-                <FitnessCenterDetail center={selected} />
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
     </section>
+
+    {/* Modal — moved outside <section> via React Portal to escape the
+        CSS transform stacking context created by the fade-in animation.
+        This ensures the backdrop covers the full viewport. */}
+    {modalOpen && selected && createPortal(
+      <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-10">
+        {/* Fix 1: backdrop is now fixed (not absolute) — covers full viewport */}
+        <div
+          className="fixed inset-0 bg-black/40 backdrop-blur-sm"
+          onClick={() => setModalOpen(false)}
+          aria-hidden
+        />
+
+        {/* Fix 2: close button is now inside the modal card */}
+        <div className="relative z-10 w-full max-w-3xl mx-auto">
+          <button
+            type="button"
+            onClick={() => setModalOpen(false)}
+            className="absolute -top-3 -right-3 z-20 bg-white rounded-full p-2 border border-stone-200 shadow-md text-stone-600 hover:bg-stone-50 transition-colors"
+            aria-label="Close"
+          >
+            ×
+          </button>
+          {/* Fix 3: removed redundant white box wrapper — FitnessCenterDetail renders its own */}
+          <FitnessCenterDetail center={selected} />
+        </div>
+      </div>,
+      document.body
+    )}
+    </>
   );
 }


### PR DESCRIPTION
## 📋 What does this PR do?
Fixes the visually broken fitness center detail modal in the `NearbyFitnessCenters` component.

The modal had three issues:
1. **Backdrop was cropped** — only covered the `<section>` instead of the full viewport, because the `fade-in` CSS animation applies `transform: translateY()` on the parent `<section>`, which creates a new CSS stacking context that traps `position: fixed` children inside it.
2. **Close button was outside the modal box** — it was `position: absolute` inside an extra `p-4` padding wrapper, which pushed it outside the white card boundary.
3. **Double white box** — `NearbyFitnessCenters` wrapped `FitnessCenterDetail` in a redundant `bg-white rounded-2xl p-6` div, while `FitnessCenterDetail` already renders its own white card, causing double-bordered appearance.

---
## ✅ Issue #192 — Fully Resolved
---

| Original Issue | Required Fix | Our Fix | Status |
|---|---|---|---|
| Backdrop cropped — only covers the section | `fixed inset-0` spanning full viewport | Portal + `fixed inset-0` backdrop | ✅ Done |
| Background content partially visible/blurred incorrectly | Proper dark overlay on full screen | `bg-black/40 backdrop-blur-sm` on full viewport | ✅ Done |
| Close button outside the modal boundary | Position relative to modal container | `absolute -top-3 -right-3` on `relative` modal wrapper | ✅ Done |
| Modal not centered properly | `flex items-center justify-center` | `fixed inset-0 flex items-center justify-center` | ✅ Done |
| z-index layering broken | Check z-index between backdrop and content | `z-50` outer → `z-10` content → `z-20` button | ✅ Done |

---

## 🔗 Related Issue
Closes #192

##  How was this tested?
Tested manually on Chrome (localhost):
1. Logged in and navigated to `/home`
2. Scrolled to the **Nearby Fitness Centers** section
3. Clicked on a fitness center card
4. Verified the modal renders correctly:
   - Dark backdrop covers the **full viewport**
   - Modal is **centered** on screen
   - Close (×) button is **inside** the modal card boundary
   - No double white box / double border

## 📸 Screenshots (if UI changes)
<img width="2852" height="1310" alt="image" src="https://github.com/user-attachments/assets/a8354824-6e41-4818-a934-0df5bfccfe35" />


https://github.com/user-attachments/assets/7c60690b-7f32-4fc3-b9c0-7093c8b4e0ae




**Before (Broken):**
- Backdrop only covers the section, background content visible on sides
- × button floating outside the modal card

**After (Fixed):**
- Full-screen dark backdrop with blur
- Modal perfectly centered
- × button neatly positioned at top-right corner of the card

## ✅ Checklist
- [✅] I've read the CONTRIBUTING guide
- [✅] My code follows the project's style guidelines
- [✅] I've tested my changes locally
- [✅] I've linked the related issue
- [✅] I haven't introduced any new secrets or API keys
