### PR TITLE
fix(env): validate firebase admin credentials conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ ALLOWED_ORIGIN=http://localhost:5173    # comma-separate multiple origins
 FIREBASE_PROJECT_ID=<your_firebase_project_id>
 FIREBASE_CLIENT_EMAIL=<your_firebase_client_email>
 FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+GOOGLE_APPLICATION_CREDENTIALS=<path_to_service_account_json>
 
 # Admin UID (used by bug routes to guard admin actions)
 ADMIN_UID=<firebase_uid_of_admin_account>
@@ -484,7 +485,15 @@ SMTP_FROM=noreply@fitmart.com
 APP_BASE_URL=http://localhost:5173
 ```
 
-> **Startup behaviour:** The server validates environment variables on startup. `MONGO_URI` is the only truly critical variable — the server will exit if it's missing. All other variables are optional; missing ones produce a warning and disable the corresponding feature gracefully.
+**Startup behaviour:** The server validates environment variables on startup.
+`MONGO_URI` and Firebase Admin credentials are critical variables.
+
+Firebase Admin can be configured using either:
+- `GOOGLE_APPLICATION_CREDENTIALS`
+OR
+- `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, and `FIREBASE_PRIVATE_KEY`
+
+The server will exit if the required configuration is missing. All other variables are optional; missing ones produce a warning and disable the corresponding feature gracefully.
 
 #### Getting Firebase Admin Credentials
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -12,3 +12,6 @@ VITE_FIREBASE_MEASUREMENT_ID=your_firebase_measurement_id
 
 # Razorpay Configuration
 VITE_RAZORPAY_KEY_ID=your_razorpay_key_id
+
+# Admin Configuration
+VITE_ADMIN_UID=your_admin_uid

--- a/server/.env.example
+++ b/server/.env.example
@@ -16,6 +16,10 @@ RAZORPAY_KEY_SECRET=your_razorpay_key_secret
 FIREBASE_PROJECT_ID=your_firebase_project_id
 FIREBASE_CLIENT_EMAIL=your_firebase_client_email
 FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+GOOGLE_APPLICATION_CREDENTIALS=your_google_application_credentials_path
+
+# Admin UID
+ADMIN_UID=your_admin_uid
 
 # Gemini Configuration
 GEMINI_API_KEY=your_gemini_api_key

--- a/server/index.js
+++ b/server/index.js
@@ -23,9 +23,6 @@ const OPTIONAL_ENV_VARS = [
   "RAZORPAY_KEY_SECRET",
   "MONGO_DB",
   "PORT",
-  "FIREBASE_PROJECT_ID",
-  "FIREBASE_CLIENT_EMAIL",
-  "FIREBASE_PRIVATE_KEY",
   "SMTP_HOST",
   "SMTP_PORT",
   "SMTP_USER",
@@ -33,6 +30,14 @@ const OPTIONAL_ENV_VARS = [
 ];
 
 const missingCritical = CRITICAL_ENV_VARS.filter((v) => !process.env[v]);
+
+if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+  const firebaseVars = ["FIREBASE_PROJECT_ID", "FIREBASE_CLIENT_EMAIL", "FIREBASE_PRIVATE_KEY"];
+  firebaseVars.forEach((v) => {
+    if (!process.env[v]) missingCritical.push(v);
+  });
+}
+
 const missingOptional = OPTIONAL_ENV_VARS.filter((v) => !process.env[v]);
 
 if (missingCritical.length > 0) {


### PR DESCRIPTION
## 📋 What does this PR do?

Improves environment variable validation and documentation for Firebase Admin configuration.

### Changes made:

* Added conditional Firebase Admin credential validation in `server/index.js`
* Added support for `GOOGLE_APPLICATION_CREDENTIALS`
* Updated `README.md` to accurately document startup validation behavior
* Updated `server/.env.example` with missing Firebase and admin variables
* Updated `client/.env.example` to include `VITE_ADMIN_UID`

### New validation behavior:

The server now supports two valid Firebase Admin setup methods:

1. Using `GOOGLE_APPLICATION_CREDENTIALS`
2. Using:

   * `FIREBASE_PROJECT_ID`
   * `FIREBASE_CLIENT_EMAIL`
   * `FIREBASE_PRIVATE_KEY`

If neither configuration is properly provided, the server exits with a clear error message.

## 🔗 Related Issue

Closes #94 

## 🧪 How was this tested?

* Verified the validation logic in `server/index.js`
* Confirmed the server requires Firebase credentials only when `GOOGLE_APPLICATION_CREDENTIALS` is not provided
* Reviewed `git diff` to ensure README documentation matches runtime behavior
* Checked `.env.example` files for consistency with the documented setup

## 📸 Screenshots (if UI changes)

No UI changes.

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys
