### PR TITLE
feat(auth): add email verification and resend link

### DIFF
--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -8,6 +8,8 @@ import {
   GoogleAuthProvider,
   sendPasswordResetEmail,
   updateProfile,
+  sendEmailVerification,
+  signOut,
 } from "firebase/auth";
 import { auth } from "../auth/firebase";
 
@@ -45,9 +47,20 @@ export default function Authentication() {
   const [loading, setLoading] = useState(false);
   const [resetSent, setResetSent] = useState(false);
   const [visible, setVisible] = useState(false);
+  const [resendDisabled, setResendDisabled] = useState(false);
+  const [resendTimer, setResendTimer] = useState(0);
 
   useEffect(() => { document.title = "Login - FitMart"; }, []);
   useEffect(() => { setTimeout(() => setVisible(true), 80); }, []);
+  useEffect(() => {
+    let interval = null;
+    if (resendTimer > 0) {
+      interval = setInterval(() => setResendTimer((t) => t - 1), 1000);
+    } else {
+      setResendDisabled(false);
+    }
+    return () => clearInterval(interval);
+  }, [resendTimer]);
 
   const handleChange = (e) => {
     setForm((p) => ({ ...p, [e.target.name]: e.target.value }));
@@ -73,6 +86,12 @@ export default function Authentication() {
     setLoading(true);
     try {
       const cred = await signInWithEmailAndPassword(auth, form.email, form.password);
+      if (!cred.user.emailVerified) {
+        // Keep user signed in so resend can use auth.currentUser
+        setError("");
+        setMode("pending-verification");
+        return;
+      }
       navigate(cred?.user?.uid === ADMIN_UID ? "/admin/dashboard" : "/home");
     } catch (err) {
       setError(parseError(err.code));
@@ -89,7 +108,11 @@ export default function Authentication() {
     try {
       const cred = await createUserWithEmailAndPassword(auth, form.email, form.password);
       if (form.name.trim()) await updateProfile(cred.user, { displayName: form.name.trim() });
-      navigate(cred?.user?.uid === ADMIN_UID ? "/admin/dashboard" : "/home");
+      await sendEmailVerification(cred.user);
+      // Keep user signed in so resend can use auth.currentUser
+      setResendDisabled(true);
+      setResendTimer(60);
+      setMode("pending-verification");
     } catch (err) {
       setError(parseError(err.code));
     } finally {
@@ -110,6 +133,34 @@ export default function Authentication() {
     }
   };
 
+  const handleResendVerification = async () => {
+    if (resendDisabled) return;
+    setLoading(true);
+    setError("");
+    try {
+      const user = auth.currentUser;
+      if (!user) {
+        // Fallback: sign in if session was lost (e.g. page refresh)
+        const cred = await signInWithEmailAndPassword(auth, form.email, form.password);
+        await sendEmailVerification(cred.user);
+      } else {
+        await sendEmailVerification(user);
+      }
+      setResendDisabled(true);
+      setResendTimer(60);
+    } catch (err) {
+      if (err.code === "auth/too-many-requests") {
+        setError("Firebase is rate-limiting requests. Please wait a few minutes before trying again.");
+        setResendDisabled(true);
+        setResendTimer(120);
+      } else {
+        setError(parseError(err.code));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleReset = async (e) => {
     e.preventDefault();
     if (!form.email) { setError("Please enter your email address."); return; }
@@ -125,10 +176,16 @@ export default function Authentication() {
   };
 
   const switchMode = (m) => {
+    // Sign out when leaving pending-verification screen
+    if (mode === "pending-verification" && m !== "pending-verification") {
+      signOut(auth);
+    }
     setMode(m);
     setError("");
     setResetSent(false);
-    setForm({ name: "", email: "", password: "", confirm: "" });
+    if (m !== "pending-verification") {
+      setForm({ name: "", email: "", password: "", confirm: "" });
+    }
   };
 
   return (
@@ -201,7 +258,7 @@ export default function Authentication() {
         <div className={`auth-panel ${visible ? "visible" : ""} w-full max-w-sm`}>
 
           {/* Mode Tabs */}
-          {mode !== "reset" && (
+          {mode !== "reset" && mode !== "pending-verification" && (
             <div className="flex border-b border-stone-200 mb-6 sm:mb-8">
               {["signin", "signup"].map((m) => (
                 <button
@@ -420,6 +477,44 @@ export default function Authentication() {
                   </button>
                 </form>
               )}
+            </div>
+          )}
+
+          {/* ── PENDING VERIFICATION ── */}
+          {mode === "pending-verification" && (
+            <div>
+              <button
+                onClick={() => switchMode("signin")}
+                className="flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-600
+                           transition-colors mb-6 min-h-9"
+              >
+                ← Back to Sign In
+              </button>
+
+              <h3 className="font-['DM_Serif_Display'] text-2xl text-stone-900 mb-2">
+                Verify your email
+              </h3>
+              <p className="text-sm text-stone-500 mb-6 sm:mb-7 leading-relaxed">
+                We've sent a verification link to <span className="font-medium">{form.email}</span>.
+                Please verify your email address to continue.
+              </p>
+
+              <div className="bg-stone-100 border border-stone-200 rounded-xl px-5 py-5 text-center">
+                <p className="text-sm text-stone-700 font-medium mb-3">Didn't receive the email?</p>
+                {error && (
+                  <p className="text-xs text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2 mb-3 text-left">
+                    {error}
+                  </p>
+                )}
+                <button
+                  onClick={handleResendVerification}
+                  disabled={loading || resendDisabled}
+                  className="w-full bg-stone-900 text-white text-sm py-3 rounded-lg
+                             hover:bg-stone-700 transition-colors disabled:opacity-50 min-h-12"
+                >
+                  {loading ? "Sending..." : resendDisabled ? `Resend in ${resendTimer}s` : "Resend Verification Email"}
+                </button>
+              </div>
             </div>
           )}
         </div>

--- a/server/middleware/verifyFirebaseToken.js
+++ b/server/middleware/verifyFirebaseToken.js
@@ -12,6 +12,11 @@ const verifyFirebaseToken = async (req, res, next) => {
 
   try {
     const decoded = await admin.auth().verifyIdToken(token);
+
+    if (!decoded.email_verified) {
+      return res.status(403).json({ error: 'Forbidden — email not verified' });
+    }
+
     req.user = decoded;
     next();
   } catch (err) {


### PR DESCRIPTION
## 📋 What does this PR do?
Adds mandatory email verification for new signups and unverified logins. Users must verify their email before accessing the app. Includes a resend verification email button with a 60s cooldown to prevent spam.

## 🔗 Related Issue
Security — unverified emails could bypass authentication and access the app

## 🧪 How was this tested?
- Signed up with a new email → received verification email
- Tried logging in without verifying → blocked and shown verification screen
- Clicked resend → received new email with 60s cooldown
- Verified email → login works normally
- Google sign-in still works without verification step

## 📸 Screenshots
### Resend Link
<img width="1917" height="908" alt="Resend Link" src="https://github.com/user-attachments/assets/8a959c88-a338-4ce3-ba43-88d0982fa769" />

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
- [x] I've updated README.md if I added a new route, page, component, or env variable
