### PR TITLE
feat(client): extend PropTypes validation to additional components

### DIFF
--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
+import PropTypes from "prop-types";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessCenterDetail from "./FitnessCenterDetail";
 
@@ -148,3 +149,10 @@ export default function NearbyFitnessCenters({ visible = true }) {
     </>
   );
 }
+Stars.propTypes = {
+  rating: PropTypes.number,
+};
+
+NearbyFitnessCenters.propTypes = {
+  visible: PropTypes.bool,
+};

--- a/client/src/components/ReportBugButton.jsx
+++ b/client/src/components/ReportBugButton.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../auth/useAuth';
+import PropTypes from "prop-types";
 
 const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
@@ -573,3 +574,12 @@ export default function ReportBugButton() {
     </>
   );
 }
+Toast.propTypes = {
+  type: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  onDismiss: PropTypes.func.isRequired,
+};
+
+FieldError.propTypes = {
+  msg: PropTypes.string.isRequired,
+};

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -6,6 +6,7 @@ import { onAuthStateChanged } from "firebase/auth";
 import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
+import PropTypes from "prop-types";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -313,3 +314,7 @@ function EmptyCart({ navigate }) {
     </div>
   );
 }
+PageShell.propTypes = {
+  children: PropTypes.node.isRequired,
+  menuOpen: PropTypes.bool,
+};


### PR DESCRIPTION
## Changes Made

* Added PropTypes validation to NearbyFitnessCenters
* Added PropTypes validation to ReportBugButton helpers
* Added PropTypes validation to Checkout PageShell
* Added required prop definitions using PropTypes

## Testing

* Ran app locally using Vite
* Verified app builds without PropTypes errors
