### PR TITLE
docs: clean env example formatting

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -12,3 +12,6 @@ VITE_FIREBASE_MEASUREMENT_ID=your_firebase_measurement_id
 
 # Razorpay Configuration
 VITE_RAZORPAY_KEY_ID=your_razorpay_key_id
+
+# Admin Configuration
+VITE_ADMIN_UID=your_admin_firebase_uid

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,4 +1,3 @@
-```env
 # =========================================
 # Server Configuration
 # =========================================
@@ -71,4 +70,3 @@ SMTP_USER=your_smtp_email
 SMTP_PASS=your_smtp_password
 
 SMTP_FROM=noreply@fitmart.com
-```


### PR DESCRIPTION
## What changed
- Removed Markdown code fences from `server/.env.example`
- Added missing `VITE_ADMIN_UID` placeholder to `client/.env.example`
- Kept environment example files directly copyable into `.env`

## Why
`.env.example` files should be plain dotenv-compatible files so contributors can copy them into `.env` without manually removing Markdown formatting.

## Testing
- Verified client build with `npm run build`
- Checked updated `.env.example` files manually