### PR TITLE
fix: redact sensitive data in logger middleware

### DIFF
--- a/server/middleware/logger.js
+++ b/server/middleware/logger.js
@@ -10,6 +10,7 @@ const SENSITIVE_KEY_PATTERNS = [
   /token/i,
   /secret/i,
   /authorization/i,
+  /credential/i,
   /cookie/i,
   /api[_-]?key/i,
   /private[_-]?key/i,
@@ -116,7 +117,7 @@ const logger = (req, res, next) => {
         if (bodyStr.length < MAX_BODY_LOG_LENGTH) {
           console.log(`   [${getTimestamp()}] Body: ${bodyStr}`);
         } else {
-          console.log(`   [${getTimestamp()}] Body: [too large to log]`);
+          console.log(`   [${getTimestamp()}] Body: [too large to log: ${bodyStr.length} chars]`);
         }
       } catch (err) {
         console.log(`   [${getTimestamp()}] Body: [error parsing body]`);

--- a/server/middleware/logger.js
+++ b/server/middleware/logger.js
@@ -1,23 +1,78 @@
 // server/middleware/logger.js
 
-// server/middleware/logger.js
+const MAX_BODY_LOG_LENGTH = 1000;
 
-// Function to get base route only
-const getBaseRoute = (url) => {
-  // Match patterns like /api/cart, /api/products, /api/orders
-  const match = url.match(/^(\/api\/(?:cart|products|orders))/);
-  if (match) {
-    // If it's a cart route with additional path, append the action
-    if (url.includes('/cart/') && !url.match(/^\/api\/cart\/?$/)) {
-      if (url.includes('/add')) return '/api/cart/add';
-      if (url.includes('/remove')) return '/api/cart/remove';
-    }
-    return match[1];
+const SENSITIVE_KEY_PATTERNS = [
+  /password/i,
+  /passcode/i,
+  /pin/i,
+  /otp/i,
+  /token/i,
+  /secret/i,
+  /authorization/i,
+  /cookie/i,
+  /api[_-]?key/i,
+  /private[_-]?key/i,
+  /client[_-]?secret/i,
+  /access[_-]?token/i,
+  /refresh[_-]?token/i,
+  /razorpay[_-]?key[_-]?secret/i,
+  /firebase[_-]?private[_-]?key/i,
+];
+
+const getTimestamp = () => new Date().toISOString();
+
+const isSensitiveKey = (key = '') =>
+  SENSITIVE_KEY_PATTERNS.some((pattern) => pattern.test(key));
+
+const sanitizeForLog = (value, seen = new WeakSet()) => {
+  if (value === null || value === undefined) {
+    return value;
   }
-  return url;
+
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeForLog(item, seen));
+  }
+
+  return Object.entries(value).reduce((sanitized, [key, nestedValue]) => {
+    sanitized[key] = isSensitiveKey(key)
+      ? '[REDACTED]'
+      : sanitizeForLog(nestedValue, seen);
+
+    return sanitized;
+  }, {});
 };
 
-// Simple logger with colors (without timestamps)
+// Function to get base route only and avoid logging query parameters
+const getBaseRoute = (url) => {
+  const pathname = url.split('?')[0];
+
+  // Match patterns like /api/cart, /api/products, /api/orders
+  const match = pathname.match(/^(\/api\/(?:cart|products|orders))/);
+  if (match) {
+    // If it's a cart route with additional path, append the action
+    if (pathname.includes('/cart/') && !pathname.match(/^\/api\/cart\/?$/)) {
+      if (pathname.includes('/add')) return '/api/cart/add';
+      if (pathname.includes('/remove')) return '/api/cart/remove';
+    }
+
+    return match[1];
+  }
+
+  return pathname;
+};
+
+// Logger with timestamps and sensitive request body redaction
 const logger = (req, res, next) => {
   const start = Date.now();
 
@@ -25,49 +80,46 @@ const logger = (req, res, next) => {
     const duration = Date.now() - start;
     const status = res.statusCode;
     const simplifiedUrl = getBaseRoute(req.originalUrl);
-    const timestamp = new Date().toISOString();
+    const timestamp = getTimestamp();
 
     const methodColor = {
-      'GET': '\x1b[34m',
-      'POST': '\x1b[32m',
-      'PUT': '\x1b[33m',
-      'DELETE': '\x1b[31m',
-      'PATCH': '\x1b[35m',
+      GET: '\x1b[34m',
+      POST: '\x1b[32m',
+      PUT: '\x1b[33m',
+      DELETE: '\x1b[31m',
+      PATCH: '\x1b[35m',
     }[req.method] || '\x1b[0m';
 
-    const statusColor = status >= 500 ? '\x1b[31m' :
-      status >= 400 ? '\x1b[33m' :
-        status >= 300 ? '\x1b[36m' :
-          status >= 200 ? '\x1b[32m' :
-            '\x1b[0m';
+    const statusColor =
+      status >= 500
+        ? '\x1b[31m'
+        : status >= 400
+          ? '\x1b[33m'
+          : status >= 300
+            ? '\x1b[36m'
+            : status >= 200
+              ? '\x1b[32m'
+              : '\x1b[0m';
 
     console.log(
       `[${timestamp}] ` +
-      `${methodColor}${req.method.padEnd(6)}\x1b[0m ` +
-      `${statusColor}${status}\x1b[0m ` +
-      `${simplifiedUrl} (${duration}ms)`
+        `${methodColor}${req.method.padEnd(6)}\x1b[0m ` +
+        `${statusColor}${status}\x1b[0m ` +
+        `${simplifiedUrl} (${duration}ms)`
     );
 
     if (req.method !== 'GET' && Object.keys(req.body || {}).length > 0) {
       try {
-        const sensitiveKeys = ['password', 'token', 'secret', 'apiKey'];
-        const safeBody = { ...req.body };
-
-        sensitiveKeys.forEach((key) => {
-          if (safeBody[key]) {
-            safeBody[key] = '[REDACTED]';
-          }
-        });
-
+        const safeBody = sanitizeForLog(req.body);
         const bodyStr = JSON.stringify(safeBody);
 
-        if (bodyStr.length < 1000) {
-          console.log(`   Body: ${bodyStr}`);
+        if (bodyStr.length < MAX_BODY_LOG_LENGTH) {
+          console.log(`   [${getTimestamp()}] Body: ${bodyStr}`);
         } else {
-          console.log(`   Body: [too large to log]`);
+          console.log(`   [${getTimestamp()}] Body: [too large to log]`);
         }
       } catch (err) {
-        console.log(`   Body: [error parsing body]`);
+        console.log(`   [${getTimestamp()}] Body: [error parsing body]`);
       }
     }
   });


### PR DESCRIPTION
## What changed
- Added recursive request body sanitization before logging
- Redacted sensitive fields such as passwords, tokens, secrets, API keys, private keys, authorization data, OTPs, PINs, cookies, and client secrets
- Added timestamps to request body log lines
- Avoided logging query parameters in route output
- Updated logger comments to match the current behavior

## Why
Request body logging can accidentally expose sensitive user or service data in server logs. This keeps logs useful while reducing the chance of leaking credentials or tokens.

## Testing
- Verified logger syntax with `node -c server/middleware/logger.js`

Fixes #168