### PR TITLE
refactor(payment): extract order service and remove axios dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
-        "axios": "^1.16.0",
         "cloudinary": "^2.10.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
-    "axios": "^1.16.0",
     "cloudinary": "^2.10.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -1,9 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const Order = require('../models/Order');
-const Cart = require('../models/Cart');
-const Product = require('../models/Product');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
+const { createOrder } = require('../services/orderService');
 
 /**
  * @route   POST /api/orders
@@ -23,50 +22,17 @@ router.post('/', verifyFirebaseToken, async (req, res) => {
   }
 
   try {
-    let orderItems = items;
-    if (!orderItems || !orderItems.length) {
-      const cart = await Cart.findOne({ userId });
-      if (!cart || !cart.items.length) return res.status(400).json({ error: 'Cart is empty' });
-      orderItems = cart.items.map(i => ({ productId: i.productId, quantity: i.quantity }));
-    }
-
-    // Build order items with price snapshot
-    const populated = [];
-    let total = 0;
-    for (const it of orderItems) {
-      const p = await Product.findOne({ productId: Number(it.productId) });
-      if (!p) return res.status(400).json({ error: `Product ${it.productId} not found` });
-      // Oversell guard - skip check if stock is null (unlimited)
-      if (p.stock !== null) {
-        const available = p.stock - p.reserved;
-        if (available < it.quantity) {
-          return res.status(400).json({
-            error: `Insufficient stock for ${p.name}. Available: ${available}`
-          });
-        }
-      }
-      populated.push({ productId: p.productId, quantity: it.quantity, price: p.price });
-      total += p.price * it.quantity;
-    }
-
-    // After order is created, deduct stock and reserved for each item
-    const order = await Order.create({ userId, items: populated, total });
-    for (const it of orderItems) {
-      const p = await Product.findOne({ productId: Number(it.productId) });
-      if (p && p.stock !== null) {
-        await Product.findOneAndUpdate(
-          { productId: p.productId },
-          { $inc: { stock: -it.quantity, reserved: -it.quantity } }
-        );
-      }
-    }
-
-    // clear cart (do NOT release reserved - purchasing finalizes reservation)
-    await Cart.findOneAndUpdate({ userId }, { items: [] });
-
+    const order = await createOrder(userId, items);
     res.status(201).json(order);
   } catch (err) {
-    console.error(err);
+    console.error('Order creation error:', err.message);
+    if (
+      err.message === 'Cart is empty' ||
+      err.message.includes('not found') ||
+      err.message.includes('Insufficient stock')
+    ) {
+      return res.status(400).json({ error: err.message });
+    }
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -1,6 +1,5 @@
 // server/routes/payment.js
 
-const axios = require("axios");
 const express = require("express");
 const Razorpay = require("razorpay");
 const crypto = require("crypto");
@@ -10,6 +9,7 @@ const Cart = require("../models/Cart");
 const Product = require("../models/Product");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
 const { sendFirstPurchaseEmail } = require("../services/firstPurchaseEmailService");
+const { createOrder } = require("../services/orderService");
 
 const razorpay = new Razorpay({
   key_id: process.env.RAZORPAY_KEY_ID,
@@ -93,27 +93,32 @@ router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
       return res.json({ success: true, message: "Order already created" });
     }
 
-    // STEP 2: Create order using existing route logic
-    const orderResponse = await axios.post(
-      "http://localhost:5000/api/orders",
-      { userId },
-      { headers: { Authorization: req.headers.authorization } }
-    );
+    // STEP 2: Create order using service logic
+    let order;
+    try {
+      order = await createOrder(userId);
+    } catch (createErr) {
+      return res.status(400).json({ error: createErr.message });
+    }
 
     //  STEP 3: Attach paymentId to order
-    await Order.findByIdAndUpdate(orderResponse.data._id, {
+    await Order.findByIdAndUpdate(order._id, {
       paymentId: razorpay_payment_id,
       status: "paid"
     });
 
+    // Update local object to reflect changes
+    order.paymentId = razorpay_payment_id;
+    order.status = "paid";
+
     // STEP 4: Send first-purchase email (non-blocking)
     // Email sending should not fail the payment flow
-    sendFirstPurchaseEmail(userId, orderResponse.data).catch((err) => {
+    sendFirstPurchaseEmail(userId, order).catch((err) => {
       console.error("First-purchase email service error:", err.message);
       // Don't throw — email failure should not break payment success
     });
 
-    res.json({ success: true, order: orderResponse.data });
+    res.json({ success: true, order });
 
   } catch (err) {
     console.error("verify-payment error:", err);
@@ -160,54 +165,28 @@ router.post("/demo-success", async (req, res) => {
 
     // Generate a fake payment ID that looks like a real Razorpay one
     const fakePaymentId = `pay_DEMO_${Date.now()}`;
-    // Create an order from the user's cart (snapshot prices, deduct stock, finalize reservation)
+    
+    // Create an order from the user's cart using the shared service
     const Order = require("../models/Order");
-
-    const cart = await Cart.findOne({ userId });
-    if (!cart || !cart.items.length) {
-      // Still clear any empty cart just in case
-      await Cart.findOneAndUpdate({ userId }, { $set: { items: [] } }, { new: true });
-      return res.status(400).json({ error: "Cart is empty" });
-    }
-
-    const populated = [];
-    let total = 0;
-    for (const it of cart.items) {
-      const p = await Product.findOne({ productId: Number(it.productId) });
-      if (!p) return res.status(400).json({ error: `Product ${it.productId} not found` });
-      const reserved = Number(p.reserved || 0);
-      if (p.stock !== null) {
-        const available = Number(p.stock) - reserved;
-        if (available < it.quantity) {
-          return res.status(400).json({ error: `Insufficient stock for ${p.name}. Available: ${available}` });
-        }
+    let order;
+    try {
+      order = await createOrder(userId);
+    } catch (createErr) {
+      if (createErr.message === "Cart is empty") {
+         // Still clear any empty cart just in case
+         await Cart.findOneAndUpdate({ userId }, { $set: { items: [] } }, { new: true });
       }
-      populated.push({ productId: p.productId, quantity: it.quantity, price: p.price });
-      total += p.price * it.quantity;
+      return res.status(400).json({ error: createErr.message });
     }
 
-    const order = await Order.create({ userId, items: populated, total, paymentId: fakePaymentId, status: "paid" });
-
-    // Deduct stock and reserved for each item safely (avoid negative reserved)
-    for (const it of cart.items) {
-      const p = await Product.findOne({ productId: Number(it.productId) });
-      if (!p) continue;
-      const currentReserved = Number(p.reserved || 0);
-      const newReserved = Math.max(0, currentReserved - it.quantity);
-      const update = {};
-      if (p.stock !== null) {
-        update.stock = Number(p.stock) - it.quantity;
-      }
-      update.reserved = newReserved;
-
-      await Product.findOneAndUpdate(
-        { productId: p.productId },
-        { $set: update }
-      );
-    }
-
-    // Clear cart (purchasing finalizes reservation)
-    await Cart.findOneAndUpdate({ userId }, { $set: { items: [] } });
+    // Attach paymentId to order
+    await Order.findByIdAndUpdate(order._id, {
+      paymentId: fakePaymentId,
+      status: "paid"
+    });
+    
+    order.paymentId = fakePaymentId;
+    order.status = "paid";
 
     // Send first-purchase email (non-blocking)
     // Email sending should not fail the payment flow

--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -1,0 +1,76 @@
+// server/services/orderService.js
+const Order = require('../models/Order');
+const Cart = require('../models/Cart');
+const Product = require('../models/Product');
+
+/**
+ * Creates an order from explicit items or the user's cart.
+ * Snapshots product prices, checks stock, creates the order,
+ * deducts stock, and clears the cart.
+ *
+ * @param {string} userId - The Firebase UID of the user
+ * @param {Array} [items] - Optional array of { productId, quantity }. If omitted, uses the cart.
+ * @returns {Promise<Object>} The created order document
+ */
+async function createOrder(userId, items = null) {
+  let orderItems = items;
+
+  // If no items are explicitly provided, fetch them from the user's cart
+  if (!orderItems || !orderItems.length) {
+    const cart = await Cart.findOne({ userId });
+    if (!cart || !cart.items.length) {
+      throw new Error('Cart is empty');
+    }
+    orderItems = cart.items.map(i => ({ productId: i.productId, quantity: i.quantity }));
+  }
+
+  // Build order items with price snapshot
+  const populated = [];
+  let total = 0;
+
+  for (const it of orderItems) {
+    const p = await Product.findOne({ productId: Number(it.productId) });
+    if (!p) {
+      throw new Error(`Product ${it.productId} not found`);
+    }
+
+    // Oversell guard - skip check if stock is null (unlimited)
+    if (p.stock !== null) {
+      const available = p.stock - (p.reserved || 0);
+      if (available < it.quantity) {
+        throw new Error(`Insufficient stock for ${p.name}. Available: ${available}`);
+      }
+    }
+
+    populated.push({ productId: p.productId, quantity: it.quantity, price: p.price });
+    total += p.price * it.quantity;
+  }
+
+  // Create the order document
+  const order = await Order.create({ userId, items: populated, total });
+
+  // Deduct stock and reserved amounts for each item
+  for (const it of orderItems) {
+    const p = await Product.findOne({ productId: Number(it.productId) });
+    if (p && p.stock !== null) {
+      // Safely calculate new reserved to avoid negative values
+      const currentReserved = Number(p.reserved || 0);
+      const newReserved = Math.max(0, currentReserved - it.quantity);
+      
+      await Product.findOneAndUpdate(
+        { productId: p.productId },
+        { 
+          $inc: { stock: -it.quantity },
+          $set: { reserved: newReserved }
+        }
+      );
+    }
+  }
+
+  // Clear the user's cart (purchasing finalizes reservation)
+  await Cart.findOneAndUpdate({ userId }, { items: [] });
+
+  return order;
+}
+
+module.exports = { createOrder };


### PR DESCRIPTION
## 📋 What does this PR do?
- Extracts the order creation logic from `server/routes/orders.js` into a shared service (`server/services/orderService.js`).
- Refactors the payment routes (`verify-payment` and `demo-success`) to use this service directly instead of relying on a fragile, self-referential `axios` HTTP call to `localhost:5000`.
- Removes the `axios` dependency entirely as it is no longer used in the backend.

## 🔗 Related Issue
Closes #238

## 🧪 How was this tested?
- Verified that the server starts successfully without `axios`.
- Verified that the `/demo-success` payment route properly clears the cart and creates an order using the new `orderService`.

## 📸 Screenshots (if UI changes)
N/A - This is a backend-only refactor.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
