### PR TITLE
feat(infra): add docker-compose for local MongoDB development

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,24 @@ Make sure you have the following installed:
 
 ---
 
+### 🐳 Local Database via Docker (Optional)
+
+If you don't have a MongoDB Atlas account or prefer to run a local database, you can use the included Docker configuration. This will spin up a local MongoDB instance.
+
+1.  Make sure [Docker](https://www.docker.com/products/docker-desktop/) is installed and running.
+2.  Run the following command in the project root:
+
+```bash
+docker-compose up -d
+```
+
+3.  In your `server/.env`, set `MONGO_URI` to:
+```env
+MONGO_URI=mongodb://localhost:27017
+```
+
+---
+
 ### 1. Clone the Repository
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  mongodb:
+    image: mongo:7
+    container_name: fitmart-mongodb
+    restart: always
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongodb_data:/data/db
+
+volumes:
+  mongodb_data:

--- a/server/.env.example
+++ b/server/.env.example
@@ -12,7 +12,9 @@ APP_BASE_URL=http://localhost:5173
 # =========================================
 # MongoDB Configuration
 # =========================================
-MONGO_URI=your_mongodb_connection_string
+# For local development with Docker, use: mongodb://localhost:27017
+# For MongoDB Atlas, use your connection string
+MONGO_URI=mongodb://localhost:27017
 MONGO_DB=FitMart
 
 


### PR DESCRIPTION
## 📋 What does this PR do?
This PR adds an optional `docker-compose.yml` file to spin up a local MongoDB instance for development. It also updates `server/.env.example` and `README.md` to include instructions on how to use it.

## 🔗 Related Issue
Closes #265

## 🧪 How was this tested?
- Verified that `docker-compose up -d` successfully spins up a MongoDB container on port 27017.
- Verified that the server can connect to the local MongoDB instance using `mongodb://localhost:27017`.
- Verified that the changes have zero impact on the existing production/Vercel setup.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
- [x] I've updated README.md