### PR TITLE
fix: guard payment page against direct navigation

### DIFF
--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -32,6 +32,15 @@ export default function PaymentPage() {
   const [error, setError] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
 
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
+
+  if (!location.state?.items?.length) {
+    navigate("/checkout", { replace: true });
+    return null;
+  }
+
   const {
     items = [],
     total = 0,
@@ -41,14 +50,6 @@ export default function PaymentPage() {
     discountApplied = false,
     address = null,
   } = location.state || {};
-
-  useEffect(() => {
-    if (!items.length) navigate("/checkout");
-  }, [items, navigate]);
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
 
   const finishOrder = async (userId, paymentId) => {
     try {


### PR DESCRIPTION
## Summary
- Added a synchronous guard before PaymentPage renders payment UI
- Redirects direct `/payment` visits back to checkout
- Removed the old post-render `useEffect` redirect guard

## Testing
- Ran `npm run build`
- Started frontend locally with Vite
- Verified direct `/payment` navigation no longer renders broken payment summary UI
- Confirmed invalid state exits before payment UI render

Closes #253 