### PR TITLE
feat(ui): add skeleton loading states for product grid and category p…

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,7 +29,7 @@ export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        // Public routes (redirect admin users to admin dashboard)
+        {/* Public routes (redirect admin users to admin dashboard) */}
         <Route path="/" element={<NonAdminRoute><LandingPage /></NonAdminRoute>} />
         <Route path="/auth" element={<Authentication />} />
         <Route path="/home" element={<NonAdminRoute><HomePage /></NonAdminRoute>} />
@@ -103,7 +103,7 @@ export default function App() {
           }
         />
 
-        // Redirect unknown routes to NotFound
+        {/* Redirect unknown routes to NotFound */}
         <Route path="*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>

--- a/client/src/components/CategoryPillsSkeleton.jsx
+++ b/client/src/components/CategoryPillsSkeleton.jsx
@@ -1,0 +1,18 @@
+// this is skeleton feature on CategoryPillsSkeleton
+
+export default function CategoryPillsSkeleton() {
+  // Mimic: All, Equipment, Nutrition, Wearables
+  const widths = ["w-12", "w-24", "w-20", "w-24"];
+
+  return (
+    <div className="flex gap-2 mb-5 sm:mb-8 overflow-x-auto pb-1 -mx-4 px-4 sm:mx-0 sm:px-0 sm:flex-wrap">
+      {widths.map((w, i) => (
+        <div
+          key={i}
+          className={`bg-stone-200 animate-pulse h-8 ${w} rounded-full flex-shrink-0`}
+          style={{ animationDelay: `${i * 60}ms` }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/ProductCardSkeleton.jsx
+++ b/client/src/components/ProductCardSkeleton.jsx
@@ -1,0 +1,30 @@
+//  Add this skeleton Feature as  ProductCardSkeleton 
+
+export default function ProductCardSkeleton({ index = 0 }) {
+  const delay = { animationDelay: `${index * 60}ms` };
+
+  return (
+    <div className="bg-white border border-stone-100 rounded-2xl overflow-hidden flex flex-col h-full">
+      {/* Image */}
+      <div className="bg-stone-200 animate-pulse aspect-square w-full" style={delay} />
+
+      <div className="p-3 sm:p-5 flex flex-col flex-1 gap-2 sm:gap-3">
+        {/* Brand */}
+        <div className="bg-stone-200 animate-pulse h-2.5 w-1/3 rounded-full" style={delay} />
+        {/* Name */}
+        <div className="bg-stone-200 animate-pulse h-3.5 w-3/4 rounded-full" style={delay} />
+        <div className="bg-stone-200 animate-pulse h-3.5 w-1/2 rounded-full" style={delay} />
+        {/* Stars */}
+        <div className="bg-stone-200 animate-pulse h-2.5 w-1/4 rounded-full" style={delay} />
+        {/* Price + button */}
+        <div className="flex items-end justify-between mt-auto pt-1">
+          <div className="space-y-1.5">
+            <div className="bg-stone-200 animate-pulse h-4 w-16 rounded-full" style={delay} />
+            <div className="bg-stone-200 animate-pulse h-3 w-10 rounded-full" style={delay} />
+          </div>
+          <div className="bg-stone-200 animate-pulse h-8 w-24 rounded-full" style={delay} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -14,6 +14,10 @@ import BMICalculator from "../components/BMICalculator";
 import CalorieCalculator from "../components/CalorieCalculator";
 import NearbyFitnessCenters from "../components/NearbyFitnessCenters";
 import Stars from "../components/Stars";
+import ProductCardSkeleton from "../components/ProductCardSkeleton";
+import CategoryPillsSkeleton from "../components/CategoryPillsSkeleton";
+
+
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -305,13 +309,28 @@ export default function HomePage() {
   });
 
   const renderProductGrid = () => {
-    if (loading) return (
-      <div className="text-center py-12 text-stone-400">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-4
-                        border-stone-300 border-t-stone-900 mb-4" />
-        <p className="text-sm">Loading products...</p>
-      </div>
-    );
+  if (loading) return (
+  <>
+    {/* Skeleton category pills */}
+    <div className="flex gap-2 mb-5 sm:mb-8 overflow-x-auto pb-1 -mx-4 px-4 sm:mx-0 sm:px-0 sm:flex-wrap">
+      {["w-12", "w-24", "w-20", "w-24"].map((w, i) => (
+        <div
+          key={i}
+          className={`bg-stone-200 animate-pulse h-8 ${w} rounded-full flex-shrink-0`}
+          style={{ animationDelay: `${i * 60}ms` }}
+        />
+      ))}
+    </div>
+
+    {/* Skeleton product grid */}
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 md:gap-5">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <ProductCardSkeleton key={i} index={i} />
+      ))}
+    </div>
+  </>
+);
+    
     if (backendError) return (
       <div className="text-center py-12 text-stone-400">
         <p className="text-3xl mb-2">🔌</p>


### PR DESCRIPTION
…ills

## 📋 What does this PR do?
Replaces the basic spinner loading state on the HomePage with a skeleton
loading UI that mimics the shape of ProductCard and category pills.
Created `ProductCardSkeleton.jsx` and `CategoryPillsSkeleton.jsx` components
using Tailwind's `animate-pulse` with staggered wave animation.

## 🔗 Related Issue
Closes #280

## 🧪 How was this tested?
- Added a temporary setTimeout delay to simulate slow network and confirmed
  skeletons render correctly
- Tested on mobile (2-col) and desktop (4-col) grid layouts
- Verified no layout shift when real cards replace skeletons

## 📸 ScreenRecorded (UI changes)

before

https://github.com/user-attachments/assets/9726d23b-f0bb-4046-ae11-d58a6cc5c9db

After

https://github.com/user-attachments/assets/19b3087c-d484-4a7e-aa88-758cdb2b52c9


## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys