### PR TITLE
fix: tighten CORS origin validation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,7 +11,11 @@ const allowedOrigins = allowedOrigin
   .split(",")
   .map((s) => s.trim())
   .filter(Boolean);
-const isDev = process.env.NODE_ENV === "development";
+const isDev = process.env.NODE_ENV !== "production";
+
+if (isDev) {
+  allowedOrigins.push("http://localhost:5173", "http://127.0.0.1:5173");
+}
 
 // Display missing variables at server startup. Only require truly critical vars
 // to avoid failing entirely in environments where optional services (Razorpay)
@@ -74,22 +78,6 @@ const paymentLimiter = rateLimit({
 app.use(
   cors({
     origin: function (origin, callback) {
-      // Allow requests with no origin (like mobile apps or curl requests)
-      if (!origin) {
-        console.log("[CORS] Allowing request with no origin");
-        return callback(null, true);
-      }
-
-      // In development, be more permissive
-      if (
-        (isDev && origin.includes("localhost")) ||
-        origin.includes("127.0.0.1")
-      ) {
-        console.log(`[CORS] Allowing local development origin: ${origin}`);
-        return callback(null, true);
-      }
-
-      // Check against allowed origins
       if (allowedOrigins.includes(origin)) {
         console.log(`[CORS] Allowing whitelisted origin: ${origin}`);
         return callback(null, true);


### PR DESCRIPTION
## 📝 What does this PR do?

- Replaced permissive CORS origin checks with exact allowlist matching
- Removed blanket allowance for requests with no `Origin` header
- Restricted localhost development origins to explicit matches only
- Preserved existing production origin support through `ALLOWED_ORIGIN`

## 🔗 Related Issue

Closes #258

## 🧪 How was this tested?

- Ran `npm run` to inspect available backend scripts
- Verified valid localhost development origins are allowed
- Verified fake origins such as `http://evil-localhost.com` are rejected
- Confirmed unknown/no-origin requests are denied by CORS callback logic
- Checked updated `server/index.js` logic directly with Node

## 📸 Screenshots (if UI changes)

No UI changes.

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys