### PR TITLE
feat: add pagination, search, and status filters to bug tracker

### DIFF
--- a/client/src/pages/AdminBugs.jsx
+++ b/client/src/pages/AdminBugs.jsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import AdminNavbar from '../components/AdminNavbar';
 import { useAuth } from '../auth/useAuth';
 
 const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
+const LIMIT = 20;
 
 const SEGMENT_STYLES = {
   open: "bg-stone-900 text-white",
@@ -11,8 +12,7 @@ const SEGMENT_STYLES = {
 };
 
 const BugAvatar = ({ title }) => (
-  <div className={`w-8 h-8 rounded-full overflow-hidden shrink-0
-                   bg-stone-200 flex items-center justify-center`}>
+  <div className="w-8 h-8 rounded-full overflow-hidden shrink-0 bg-stone-200 flex items-center justify-center">
     <span className="text-xs font-medium text-stone-600">
       {(title?.[0] || "!").toUpperCase()}
     </span>
@@ -32,7 +32,7 @@ const SkeletonRow = () => (
 
 const Empty = () => (
   <tr>
-    <td colSpan={7} className="py-12 sm:py-16 text-center">
+    <td colSpan={8} className="py-12 sm:py-16 text-center">
       <p className="text-3xl text-stone-200 mb-3">∅</p>
       <p className="text-sm text-stone-400 mb-1">No bug reports found</p>
       <p className="text-xs text-stone-300">Bug reports will appear here when users submit them</p>
@@ -40,7 +40,6 @@ const Empty = () => (
   </tr>
 );
 
-// Mobile bug card
 const BugMobileCard = ({ bug, index, onClick, onStatusClick }) => (
   <div
     role="button"
@@ -48,13 +47,10 @@ const BugMobileCard = ({ bug, index, onClick, onStatusClick }) => (
     onClick={onClick}
     onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } }}
     onMouseDown={(e) => e.preventDefault()}
-    className="select-none flex items-start gap-3 py-3.5 border-b border-stone-100 last:border-0
-               cursor-pointer active:bg-stone-50 transition-colors"
+    className="select-none flex items-start gap-3 py-3.5 border-b border-stone-100 last:border-0 cursor-pointer active:bg-stone-50 transition-colors"
   >
     <span className="text-xs text-stone-300 w-5 shrink-0 text-center">{index + 1}</span>
-
     <BugAvatar title={bug.title} />
-
     <div className="flex-1 min-w-0">
       <div className="flex items-center gap-2 mb-0.5">
         <p className="text-sm font-medium text-stone-700 truncate">{bug.title}</p>
@@ -70,7 +66,6 @@ const BugMobileCard = ({ bug, index, onClick, onStatusClick }) => (
       <p className="text-[10px] text-stone-400 mt-1">{new Date(bug.createdAt).toLocaleString()}</p>
       <p className="text-[10px] text-stone-400 mt-1">{bug.reporterName || bug.reporterEmail || '—'}</p>
     </div>
-
     <div className="text-right shrink-0">
       <p className="text-[10px] text-stone-400">{bug.pageUrl ? 'Has URL' : 'No URL'}</p>
     </div>
@@ -83,85 +78,89 @@ export default function AdminBugs() {
   const [error, setError] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [loadingBugs, setLoadingBugs] = useState(true);
-  // Mobile status picker state: { id, status }
   const [mobilePicker, setMobilePicker] = useState(null);
 
-  const openMobilePicker = (bug) => {
-    setMobilePicker({ id: bug._id, status: bug.status });
-  };
+  // ── New filter / pagination state ──────────────────────────────────────
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [search, setSearch] = useState('');
+  const [searchInput, setSearchInput] = useState('');
+  const [page, setPage] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [summary, setSummary] = useState({});
 
+  const totalPages = Math.ceil(total / LIMIT);
+
+  const openMobilePicker = (bug) => setMobilePicker({ id: bug._id, status: bug.status });
   const closeMobilePicker = () => setMobilePicker(null);
+
+  // Debounce search input
+  useEffect(() => {
+    const t = setTimeout(() => { setSearch(searchInput); setPage(1); }, 400);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  // Reset page when filter changes
+  const handleStatusFilter = (s) => { setStatusFilter(s); setPage(1); };
+
+  // ── Fetch bugs ──────────────────────────────────────────────────────────
+  const fetchBugs = useCallback(async () => {
+    if (loading || !user) return;
+    setLoadingBugs(true);
+    try {
+      const token = await user.getIdToken();
+      const params = new URLSearchParams({ page, limit: LIMIT });
+      if (statusFilter !== 'all') params.set('status', statusFilter);
+      if (search) params.set('search', search);
+
+      const res = await fetch(`${API}/api/bugs?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (!res.ok) throw new Error('Failed to fetch');
+      const body = await res.json();
+      setBugs(body.bugs || []);
+      setTotal(body.total || 0);
+      setSummary(body.summary || {});
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load bug reports');
+    } finally {
+      setLoadingBugs(false);
+    }
+  }, [loading, user, page, statusFilter, search]);
+
+  useEffect(() => { fetchBugs(); }, [fetchBugs]);
 
   const handleMobileStatusChange = async (newStatus) => {
     if (!mobilePicker) return;
     const id = mobilePicker.id;
     const prev = bugs.find(b => b._id === id)?.status;
-    // optimistic update
     setBugs((cur) => cur.map(b => (b._id === id ? { ...b, status: newStatus } : b)));
     try {
       const token = await user.getIdToken();
-      const url = `${API}/api/bugs/${id}`;
-      const res = await fetch(url, {
+      const res = await fetch(`${API}/api/bugs/${id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ status: newStatus }),
       });
-      if (!res.ok) {
-        let body = null;
-        try { body = await res.json(); } catch (e) { body = await res.text(); }
-        console.error('PATCH failed', { url, status: res.status, body });
-        throw new Error(`update failed (${res.status})`);
-      }
+      if (!res.ok) throw new Error(`update failed (${res.status})`);
       setMobilePicker(null);
     } catch (err) {
       console.error(err);
-      // rollback
       setBugs((cur) => cur.map(b => (b._id === id ? { ...b, status: prev } : b)));
       alert('Failed to update status');
     }
   };
 
-  useEffect(() => {
-    if (loading || !user) return;
-    let mounted = true;
-    setLoadingBugs(true);
-    (async () => {
-      try {
-        const token = await user.getIdToken();
-        const res = await fetch(`${API}/api/bugs`, { headers: { Authorization: `Bearer ${token}` } });
-        if (!res.ok) throw new Error('Failed to fetch');
-        const body = await res.json();
-        if (mounted) setBugs(body.bugs || []);
-      } catch (err) {
-        console.error(err);
-        setError('Unable to load bug reports');
-      } finally {
-        if (mounted) setLoadingBugs(false);
-      }
-    })();
-    return () => { mounted = false; };
-  }, [loading, user]);
-
-  // Derived metrics for visualizations
-  const statusCounts = bugs.reduce((acc, bug) => {
-    acc[bug.status] = (acc[bug.status] || 0) + 1;
-    return acc;
-  }, {});
-
-  // sort bugs: open -> in-progress -> resolved, then new -> old
   const order = { open: 0, 'in-progress': 1, resolved: 2 };
   const sortedBugs = [...bugs].sort((a, b) => {
-    const oa = order[a.status] ?? 3;
-    const ob = order[b.status] ?? 3;
+    const oa = order[a.status] ?? 3, ob = order[b.status] ?? 3;
     if (oa !== ob) return oa - ob;
     return new Date(b.createdAt) - new Date(a.createdAt);
   });
 
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-      <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
-      `}</style>
+      <style>{`@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');`}</style>
 
       <AdminNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
 
@@ -176,6 +175,27 @@ export default function AdminBugs() {
           </h1>
         </div>
 
+        {/* ── Status Summary Bar ─────────────────────────────────────────── */}
+        {!loadingBugs && (
+          <div className="flex flex-wrap gap-2 sm:gap-4 mb-6 text-sm text-stone-500">
+            <span>
+              <span className="font-semibold text-stone-900">{summary.open ?? 0}</span> open
+            </span>
+            <span className="text-stone-300">·</span>
+            <span>
+              <span className="font-semibold text-stone-900">{summary['in-progress'] ?? 0}</span> in progress
+            </span>
+            <span className="text-stone-300">·</span>
+            <span>
+              <span className="font-semibold text-stone-900">{summary.resolved ?? 0}</span> resolved
+            </span>
+            <span className="text-stone-300">·</span>
+            <span>
+              <span className="font-semibold text-stone-900">{total}</span> total
+            </span>
+          </div>
+        )}
+
         {/* Error */}
         {error && (
           <div className="bg-red-50 border border-red-100 rounded-2xl px-4 sm:px-6 py-4 mb-6 sm:mb-8">
@@ -187,13 +207,12 @@ export default function AdminBugs() {
         {/* KPI Cards */}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 md:gap-5 mb-8 sm:mb-10">
           {[
-            { label: "Total Reports", value: bugs.length, icon: "◎" },
-            { label: "Open", value: bugs.filter(b => b.status === "open").length, icon: "⭑" },
-            { label: "Resolved", value: bugs.filter(b => b.status === "resolved").length, icon: "✓" },
+            { label: "Total Reports", value: total, icon: "◎" },
+            { label: "Open", value: summary.open ?? 0, icon: "⭑" },
+            { label: "Resolved", value: summary.resolved ?? 0, icon: "✓" },
           ].map(({ label, value, icon }) => (
             <div key={label}
-              className="bg-white border border-stone-200 rounded-2xl p-5 sm:p-7
-                         hover:border-stone-300 hover:shadow-lg transition-all duration-300">
+              className="bg-white border border-stone-200 rounded-2xl p-5 sm:p-7 hover:border-stone-300 hover:shadow-lg transition-all duration-300">
               <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-4 sm:mb-5">{label}</p>
               <div className="flex items-end justify-between">
                 {loadingBugs ? (
@@ -210,15 +229,16 @@ export default function AdminBugs() {
           ))}
         </div>
 
-        {/* Insights — status distribution */}
+        {/* Insights */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8 sm:mb-10">
           <div className="bg-white border border-stone-200 rounded-2xl p-5 sm:p-7 hover:border-stone-300 hover:shadow-lg transition-all duration-300">
             <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-4">Insights</p>
             <h3 style={{ fontFamily: "'DM Serif Display', serif" }} className="text-lg text-stone-900 mb-4">Status distribution</h3>
             <div className="space-y-3">
               {['open', 'in-progress', 'resolved'].map(status => {
-                const count = statusCounts[status] || 0;
-                const pct = bugs.length ? Math.round((count / bugs.length) * 100) : 0;
+                const count = summary[status] || 0;
+                const totalAll = (summary.open || 0) + (summary['in-progress'] || 0) + (summary.resolved || 0);
+                const pct = totalAll ? Math.round((count / totalAll) * 100) : 0;
                 return (
                   <div key={status} className="flex items-center gap-3">
                     <div className={`w-3 h-3 rounded-full ${status === 'open' ? 'bg-stone-900' : status === 'in-progress' ? 'bg-stone-100 border border-stone-300' : 'bg-stone-100'}`} />
@@ -259,41 +279,62 @@ export default function AdminBugs() {
         </div>
 
         {/* Bug list card */}
-        <div className="bg-white border border-stone-200 rounded-2xl overflow-hidden
-                        hover:border-stone-300 transition-all duration-300">
-          <div className="px-4 sm:px-7 py-4 sm:py-5 border-b border-stone-100
-                          flex justify-between items-center">
-            <div>
-              <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-0.5">Directory</p>
-              <h2 style={{ fontFamily: "'DM Serif Display', serif" }} className="text-xl text-stone-900">
-                All Reports
-              </h2>
+        <div className="bg-white border border-stone-200 rounded-2xl overflow-hidden hover:border-stone-300 transition-all duration-300">
+          <div className="px-4 sm:px-7 py-4 sm:py-5 border-b border-stone-100">
+
+            <div className="flex justify-between items-center mb-4">
+              <div>
+                <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-0.5">Directory</p>
+                <h2 style={{ fontFamily: "'DM Serif Display', serif" }} className="text-xl text-stone-900">All Reports</h2>
+              </div>
+              {!loadingBugs && <p className="text-xs text-stone-400">{total} reports</p>}
             </div>
-            {!loadingBugs && <p className="text-xs text-stone-400">{bugs.length} reports</p>}
+
+            {/* ── Search Input ─────────────────────────────────────────── */}
+            <input
+              type="text"
+              placeholder="Search by title, reporter, or URL…"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              className="w-full mb-4 px-4 py-2 text-sm border border-stone-200 rounded-full
+                         text-stone-700 placeholder-stone-300 focus:outline-none focus:border-stone-400
+                         transition-colors"
+            />
+
+            {/* ── Status Filter Pills ──────────────────────────────────── */}
+            <div className="flex flex-wrap gap-2">
+              {['all', 'open', 'in-progress', 'resolved'].map((s) => (
+                <button
+                  key={s}
+                  onClick={() => handleStatusFilter(s)}
+                  className={`px-4 py-1.5 rounded-full text-xs font-medium capitalize transition-all
+                    ${statusFilter === s
+                      ? 'bg-stone-900 text-white'
+                      : 'border border-stone-200 text-stone-500 hover:border-stone-400'
+                    }`}
+                >
+                  {s === 'all'
+                    ? `All (${total})`
+                    : `${s.replace('-', ' ')} (${summary[s] ?? 0})`}
+                </button>
+              ))}
+            </div>
           </div>
 
           {/* Mobile card list */}
           <div className="md:hidden px-4 py-2">
-            {loadingBugs && (
-              [...Array(5)].map((_, i) => (
-                <div key={i} className="h-14 bg-stone-100 rounded-xl animate-pulse mb-3" />
-              ))
-            )}
+            {loadingBugs && [...Array(5)].map((_, i) => (
+              <div key={i} className="h-14 bg-stone-100 rounded-xl animate-pulse mb-3" />
+            ))}
             {!loadingBugs && bugs.length === 0 && (
               <div className="py-12 text-center">
                 <p className="text-3xl text-stone-200 mb-3">∅</p>
                 <p className="text-sm text-stone-400 mb-1">No bug reports found</p>
-                <p className="text-xs text-stone-300">Bug reports will appear here when users submit them</p>
+                <p className="text-xs text-stone-300">Try adjusting your search or filter</p>
               </div>
             )}
             {!loadingBugs && sortedBugs.map((bug, index) => (
-              <BugMobileCard
-                key={bug._id}
-                bug={bug}
-                index={index}
-                onClick={() => { }} // Add navigation if you have a detail view
-                onStatusClick={openMobilePicker}
-              />
+              <BugMobileCard key={bug._id} bug={bug} index={index} onClick={() => {}} onStatusClick={openMobilePicker} />
             ))}
 
             {mobilePicker && (
@@ -301,18 +342,12 @@ export default function AdminBugs() {
                 <div className="max-w-2xl mx-auto">
                   <p className="text-xs text-stone-400 mb-2">Change status</p>
                   <div className="flex gap-2">
-                    <button onClick={() => handleMobileStatusChange('open')}
-                      className={`flex-1 py-2 rounded-full text-sm ${mobilePicker.status === 'open' ? 'bg-stone-900 text-white' : 'border border-stone-200 text-stone-700'}`}>
-                      Open
-                    </button>
-                    <button onClick={() => handleMobileStatusChange('in-progress')}
-                      className={`flex-1 py-2 rounded-full text-sm ${mobilePicker.status === 'in-progress' ? 'bg-stone-900 text-white' : 'border border-stone-200 text-stone-700'}`}>
-                      In Progress
-                    </button>
-                    <button onClick={() => handleMobileStatusChange('resolved')}
-                      className={`flex-1 py-2 rounded-full text-sm ${mobilePicker.status === 'resolved' ? 'bg-stone-900 text-white' : 'border border-stone-200 text-stone-700'}`}>
-                      Resolved
-                    </button>
+                    {['open', 'in-progress', 'resolved'].map(s => (
+                      <button key={s} onClick={() => handleMobileStatusChange(s)}
+                        className={`flex-1 py-2 rounded-full text-sm capitalize ${mobilePicker.status === s ? 'bg-stone-900 text-white' : 'border border-stone-200 text-stone-700'}`}>
+                        {s.replace('-', ' ')}
+                      </button>
+                    ))}
                   </div>
                   <div className="mt-3 text-center">
                     <button onClick={closeMobilePicker} className="text-xs text-stone-500">Cancel</button>
@@ -329,44 +364,32 @@ export default function AdminBugs() {
                 <tr className="border-b border-stone-100">
                   {["#", "Title", "Description", "Status", "Reported", "Reporter", "Page", "Screenshot"].map((h, i) => (
                     <th key={h}
-                      className={`px-6 py-4 text-xs tracking-[0.15em] uppercase text-stone-400
-                                  font-normal whitespace-nowrap
-                                  ${i === 0 || i === 1 || i === 2
-                          ? "text-left"
-                          : i === 4 ? "text-right" : "text-center"}`}>
+                      className={`px-6 py-4 text-xs tracking-[0.15em] uppercase text-stone-400 font-normal whitespace-nowrap
+                                  ${i === 0 || i === 1 || i === 2 ? "text-left" : i === 4 ? "text-right" : "text-center"}`}>
                       {h}
                     </th>
                   ))}
                 </tr>
               </thead>
-
               <tbody className="divide-y divide-stone-100">
                 {loadingBugs && [...Array(5)].map((_, i) => <SkeletonRow key={i} />)}
                 {!loadingBugs && bugs.length === 0 && <Empty />}
-
                 {!loadingBugs && sortedBugs.map((bug, index) => (
                   <tr key={bug._id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => { }} // Add navigation if you have a detail view
-                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); } }}
+                    role="button" tabIndex={0}
+                    onClick={() => {}}
+                    onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") e.preventDefault(); }}
                     onMouseDown={(e) => {
-                      // Allow interactive controls inside the row (select, input, button, textarea, a) to receive events.
-                      const tag = (e.target && e.target.tagName || '').toLowerCase();
+                      const tag = (e.target?.tagName || '').toLowerCase();
                       if (['select', 'option', 'input', 'button', 'a', 'textarea', 'svg', 'path'].includes(tag)) return;
                       e.preventDefault();
                     }}
                     className="select-none hover:bg-stone-50 transition-colors cursor-pointer group">
-                    <td className="px-6 py-5 text-stone-300 text-xs">{index + 1}</td>
+                    <td className="px-6 py-5 text-stone-300 text-xs">{(page - 1) * LIMIT + index + 1}</td>
                     <td className="px-6 py-5">
                       <div className="flex items-center gap-3">
                         <BugAvatar title={bug.title} />
-                        <div className="min-w-0">
-                          <p className="text-xs font-medium text-stone-700
-                                        group-hover:text-stone-900 truncate">
-                            {bug.title}
-                          </p>
-                        </div>
+                        <p className="text-xs font-medium text-stone-700 group-hover:text-stone-900 truncate">{bug.title}</p>
                       </div>
                     </td>
                     <td className="px-6 py-5">
@@ -378,9 +401,7 @@ export default function AdminBugs() {
                           value={bug.status}
                           onChange={async (e) => {
                             const newStatus = e.target.value;
-                            // optimistic update
                             const prev = bug.status;
-                            bug.status = newStatus;
                             setBugs((cur) => cur.map(b => (b._id === bug._id ? { ...b, status: newStatus } : b)));
                             try {
                               const token = await user.getIdToken();
@@ -389,15 +410,9 @@ export default function AdminBugs() {
                                 headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
                                 body: JSON.stringify({ status: newStatus }),
                               });
-                              if (!res.ok) {
-                                let body = null;
-                                try { body = await res.json(); } catch (e) { body = await res.text(); }
-                                console.error('PATCH failed', { url: `${API}/api/bugs/${bug._id}`, status: res.status, body });
-                                throw new Error(`update failed (${res.status})`);
-                              }
+                              if (!res.ok) throw new Error(`update failed (${res.status})`);
                             } catch (err) {
                               console.error(err);
-                              // rollback
                               setBugs((cur) => cur.map(b => (b._id === bug._id ? { ...b, status: prev } : b)));
                               alert('Failed to update status');
                             }
@@ -411,53 +426,57 @@ export default function AdminBugs() {
                       </div>
                     </td>
                     <td className="px-6 py-5 text-right text-stone-400 text-xs whitespace-nowrap">
-                      {new Date(bug.createdAt).toLocaleDateString("en-IN", {
-                        day: "2-digit", month: "short", year: "numeric",
-                      })}
+                      {new Date(bug.createdAt).toLocaleDateString("en-IN", { day: "2-digit", month: "short", year: "numeric" })}
                     </td>
                     <td className="px-6 py-5 text-center">
                       <div className="text-xs text-stone-600 mb-1">{bug.reporterName || '—'}</div>
                       <div className="text-xs text-stone-400">{bug.reporterEmail || '—'}</div>
                     </td>
                     <td className="px-6 py-5 text-center">
-                      {bug.pageUrl ? (
-                        <span className="text-xs text-stone-400 truncate max-w-37.5 block">
-                          {bug.pageUrl.split('/').pop() || 'page'}
-                        </span>
-                      ) : (
-                        <span className="text-xs text-stone-300">—</span>
-                      )}
+                      {bug.pageUrl
+                        ? <span className="text-xs text-stone-400 truncate max-w-37.5 block">{bug.pageUrl.split('/').pop() || 'page'}</span>
+                        : <span className="text-xs text-stone-300">—</span>}
                     </td>
                     <td className="px-6 py-5 text-center">
-                      {(bug.screenshotUrl || bug.screenshot) ? (
-                        (() => {
-                          const api = import.meta.env.VITE_API_URL || 'http://localhost:5000';
-                          const url = bug.screenshotUrl ? bug.screenshotUrl : `${api}${bug.screenshot}`;
-                          return (
-                            <a
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              onClick={e => e.stopPropagation()}
-                              className="inline-block"
-                            >
-                              <img
-                                src={url}
-                                alt="Screenshot"
-                                className="w-12 h-8 object-cover rounded border border-stone-200 hover:opacity-80 transition-opacity"
-                              />
-                            </a>
-                          );
-                        })()
-                      ) : (
-                        <span className="text-xs text-stone-300">—</span>
-                      )}
+                      {(bug.screenshotUrl || bug.screenshot) ? (() => {
+                        const url = bug.screenshotUrl ? bug.screenshotUrl : `${API}${bug.screenshot}`;
+                        return (
+                          <a href={url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()} className="inline-block">
+                            <img src={url} alt="Screenshot" className="w-12 h-8 object-cover rounded border border-stone-200 hover:opacity-80 transition-opacity" />
+                          </a>
+                        );
+                      })() : <span className="text-xs text-stone-300">—</span>}
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
+
+          {/* ── Pagination Controls ──────────────────────────────────────── */}
+          {!loadingBugs && totalPages > 1 && (
+            <div className="px-4 sm:px-7 py-4 border-t border-stone-100 flex items-center justify-between">
+              <button
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className="px-4 py-1.5 text-xs border border-stone-200 rounded-full text-stone-500
+                           hover:border-stone-400 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                ← Prev
+              </button>
+              <span className="text-xs text-stone-400">
+                Page <span className="text-stone-700 font-medium">{page}</span> of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                className="px-4 py-1.5 text-xs border border-stone-200 rounded-full text-stone-500
+                           hover:border-stone-400 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+              >
+                Next →
+              </button>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/server/routes/bugs.js
+++ b/server/routes/bugs.js
@@ -8,8 +8,6 @@ const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const admin = require('../firebaseAdmin');
 
-
-
 // Use memory storage so serverless environments (Vercel) work correctly
 const storage = multer.memoryStorage();
 const upload = multer({
@@ -30,7 +28,6 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
     if (!title || !description)
       return res.status(400).json({ error: 'Title and description are required' });
 
-    // Prefer authenticated name/email from token if present
     try {
       const authHeader = req.headers.authorization;
       if (authHeader?.startsWith('Bearer ')) {
@@ -49,19 +46,14 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
       try {
         const result = await new Promise((resolve, reject) => {
           const stream = cloudinary.uploader.upload_stream(
-            {
-              folder: 'fitmart/bugs',
-              resource_type: 'image',
-            },
+            { folder: 'fitmart/bugs', resource_type: 'image' },
             (error, result) => {
               if (error) return reject(error);
               resolve(result);
             }
           );
-
           streamifier.createReadStream(req.file.buffer).pipe(stream);
         });
-
         screenshotUrl = result.secure_url || '';
         screenshotPublicId = result.public_id || '';
       } catch (uploadErr) {
@@ -71,16 +63,9 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
     }
 
     const bug = new Bug({
-      title,
-      description,
-      steps,
-      pageUrl,
-      browser,
-      reporterName,
-      reporterEmail,
-      screenshot: '',
-      screenshotUrl,
-      screenshotPublicId,
+      title, description, steps, pageUrl, browser,
+      reporterName, reporterEmail,
+      screenshot: '', screenshotUrl, screenshotPublicId,
     });
 
     await bug.save();
@@ -91,11 +76,42 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
   }
 });
 
-// ── GET /api/bugs — admin only ────────────────────────────────────────────
-router.get('/', verifyFirebaseToken, verifyAdmin, async (_req, res) => {
+// ── GET /api/bugs — admin only, with pagination + filters ─────────────────
+router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   try {
-    const bugs = await Bug.find().sort({ createdAt: -1 }).limit(500);
-    res.json({ ok: true, bugs });
+    const { status, search, page = 1, limit = 20 } = req.query;
+
+    // Build filter dynamically
+    const filter = {};
+
+    if (status && status !== 'all') {
+      filter.status = status; // 'open' | 'in-progress' | 'resolved'
+    }
+
+    if (search) {
+      filter.$or = [
+        { title:        { $regex: search, $options: 'i' } },
+        { reporterName: { $regex: search, $options: 'i' } },
+        { pageUrl:      { $regex: search, $options: 'i' } },
+      ];
+    }
+
+    const skip = (Number(page) - 1) * Number(limit);
+
+    // Run all three queries in parallel
+    const [bugs, total, statusCounts] = await Promise.all([
+      Bug.find(filter).sort({ createdAt: -1 }).skip(skip).limit(Number(limit)),
+      Bug.countDocuments(filter),
+      Bug.aggregate([{ $group: { _id: '$status', count: { $sum: 1 } } }]),
+    ]);
+
+    // Shape into { open: 14, 'in-progress': 6, resolved: 22 }
+    const summary = statusCounts.reduce((acc, { _id, count }) => {
+      acc[_id] = count;
+      return acc;
+    }, {});
+
+    res.json({ ok: true, bugs, total, page: Number(page), limit: Number(limit), summary });
   } catch (err) {
     console.error('Error fetching bugs:', err);
     res.status(500).json({ error: 'Failed to fetch bugs' });
@@ -105,7 +121,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (_req, res) => {
 // ── PATCH /api/bugs/:id — admin only ─────────────────────────────────────
 router.patch('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   try {
-
     const { status } = req.body;
     if (!['open', 'in-progress', 'resolved'].includes(status))
       return res.status(400).json({ error: 'Invalid status' });


### PR DESCRIPTION
## What this PR does

- Updates `GET /api/bugs` to accept `status`, `search`, `page`, and `limit` query parameters
- Returns paginated results with total count and status summary
- Adds status filter pills (All / Open / In-progress / Resolved)
- Adds search input for title, reporter name, and page URL
- Adds status summary bar showing count per status
- Adds pagination controls (Prev / Next)

Fixes the 500-row DOM render performance bottleneck.