### PR TITLE
fix(inventory): unify low-stock threshold across dashboard and admin

### DIFF
--- a/client/src/constants/inventory.js
+++ b/client/src/constants/inventory.js
@@ -1,0 +1,2 @@
+/** Keep in sync with server `LOW_STOCK_THRESHOLD` (default 5). */
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -3,8 +3,7 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
-
-const LOW_STOCK_THRESHOLD = 5;
+import { LOW_STOCK_THRESHOLD } from "../constants/inventory";
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -19,6 +19,12 @@ MONGO_DB=FitMart
 
 
 # =========================================
+# Inventory Configuration
+# =========================================
+# Available stock (stock - reserved) below this value is treated as low stock
+LOW_STOCK_THRESHOLD=5
+
+# =========================================
 # Admin Configuration
 # =========================================
 ADMIN_UID=your_admin_uid

--- a/server/constants/inventory.js
+++ b/server/constants/inventory.js
@@ -1,0 +1,8 @@
+const DEFAULT_LOW_STOCK_THRESHOLD = 5;
+
+const parsed = Number.parseInt(process.env.LOW_STOCK_THRESHOLD ?? '', 10);
+
+const LOW_STOCK_THRESHOLD =
+  Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_LOW_STOCK_THRESHOLD;
+
+module.exports = { LOW_STOCK_THRESHOLD };

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -6,6 +6,7 @@ const Product = require('../models/Product');
 const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
+const { LOW_STOCK_THRESHOLD } = require('../constants/inventory');
 
 // ── Helper: resolve Firebase UID → { displayName, email } ─────────────────
 // Returns "—" gracefully if user is deleted or UID is invalid
@@ -64,9 +65,14 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
-      stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
+      stock: { $ne: null },
+      $expr: {
+        $lt: [
+          { $subtract: ['$stock', { $ifNull: ['$reserved', 0] }] },
+          LOW_STOCK_THRESHOLD,
+        ],
+      },
     });
 
     // ── 4. Chart: Revenue Over Time ───────────────────────────────────────

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Product = require('../models/Product');
+const { LOW_STOCK_THRESHOLD } = require('../constants/inventory');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 
@@ -20,12 +21,10 @@ router.get('/', async (req, res) => {
 
 /**
  * @route   GET /api/products/low-stock
- * @desc    Returns all products where available stock (stock - reserved) is below threshold of 5
+ * @desc    Returns all products where available stock (stock - reserved) is below threshold
  * @access  Public
  */
 // GET /api/products/low-stock - get products with low stock
-const LOW_STOCK_THRESHOLD = 5;
-
 router.get('/low-stock', async (req, res) => {
   try {
     // only check products where stock is not null


### PR DESCRIPTION
## Summary
- Adds shared `LOW_STOCK_THRESHOLD` constant (server reads `process.env`, default **5**)
- Replaces duplicated literals in `products.js`, `dashboard.js`, and `AdminInventory.jsx`
- Aligns dashboard low-stock KPI with **available stock** (`stock - reserved`), matching the inventory page

## Test plan
- [ ] Set products with `stock=8`, `reserved=4` → available 4 → counted as low stock at threshold 5
- [ ] Dashboard KPI matches Admin Inventory low-stock badges
- [ ] Optional: set `LOW_STOCK_THRESHOLD=10` in server `.env` and verify API behavior

Closes #242