### PR TITLE
fix(auth): link Terms and Privacy Policy on sign-up form

### DIFF
--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -437,8 +437,22 @@ export default function Authentication() {
 
               <p className="text-[11px] text-stone-400 text-center leading-relaxed">
                 By creating an account you agree to our{" "}
-                <span className="underline cursor-pointer">Terms</span> and{" "}
-                <span className="underline cursor-pointer">Privacy Policy</span>.
+                <button
+                  type="button"
+                  onClick={() => navigate("/terms")}
+                  className="underline hover:text-stone-600"
+                >
+                  Terms
+                </button>{" "}
+                and{" "}
+                <button
+                  type="button"
+                  onClick={() => navigate("/privacy-policy")}
+                  className="underline hover:text-stone-600"
+                >
+                  Privacy Policy
+                </button>
+                .
               </p>
             </form>
           )}


### PR DESCRIPTION
## Summary
- Replaces non-interactive `<span>` elements with `<button type="button">` links
- Navigates to `/terms` and `/privacy-policy` (pages already exist in the app)

## Test plan
- [ ] Open `/auth` → Create Account tab
- [ ] Click **Terms** → lands on `/terms`
- [ ] Click **Privacy Policy** → lands on `/privacy-policy`

Fixes #252