### PR TITLE
fix(server): env.example and Firebase credential handling (#94)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,9 +464,16 @@ npm run dev
 ### Server — `server/.env`
 
 ```env
-# Required
+# Required — server exits if missing
 MONGO_URI=<your_mongodb_connection_string>
 PORT=5000
+
+# Required for authentication — provide inline Firebase vars OR a credentials file
+FIREBASE_PROJECT_ID=<your_firebase_project_id>
+FIREBASE_CLIENT_EMAIL=<your_firebase_client_email>
+FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# Alternative to the three FIREBASE_* vars above:
+GOOGLE_APPLICATION_CREDENTIALS=./path/to/firebase-service-account.json
 
 # Optional — payment processing
 RAZORPAY_KEY_ID=<your_razorpay_key_id>
@@ -477,11 +484,6 @@ MONGO_DB=<your_database_name>
 
 # CORS
 ALLOWED_ORIGIN=http://localhost:5173    # comma-separate multiple origins
-
-# Firebase Admin SDK (required for auth middleware)
-FIREBASE_PROJECT_ID=<your_firebase_project_id>
-FIREBASE_CLIENT_EMAIL=<your_firebase_client_email>
-FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
 
 # Admin UID (used by bug routes to guard admin actions)
 ADMIN_UID=<firebase_uid_of_admin_account>
@@ -503,17 +505,16 @@ SMTP_FROM=noreply@fitmart.com
 APP_BASE_URL=http://localhost:5173
 ```
 
-> **Startup behaviour:** The server validates environment variables on startup. `MONGO_URI` is the only truly critical variable — the server will exit if it's missing. All other variables are optional; missing ones produce a warning and disable the corresponding feature gracefully.
+> **Startup behaviour:** The server validates environment variables on startup. `MONGO_URI` is required — the server exits if it is missing. Firebase credentials are required for auth: set all three `FIREBASE_*` variables **or** `GOOGLE_APPLICATION_CREDENTIALS` pointing at your service-account JSON. If neither is configured, startup continues but logs an error and auth-protected routes will not work. Other variables (Razorpay, SMTP, RapidAPI, etc.) are optional; missing ones produce a warning and disable the corresponding feature gracefully. See `server/.env.example` for the full list.
 
 #### Getting Firebase Admin Credentials
 
 1. Go to [Firebase Console](https://console.firebase.google.com) → **Project Settings** → **Service Accounts**
 2. Select **Node.js** and click **"Generate new private key"**
-3. A `.json` file downloads — copy these values:
-   - `project_id` → `FIREBASE_PROJECT_ID`
-   - `client_email` → `FIREBASE_CLIENT_EMAIL`
-   - `private_key` → `FIREBASE_PRIVATE_KEY` (wrap in double quotes, keep all `\n`)
-4. **Delete the `.json` file** — never commit it to GitHub
+3. A `.json` file downloads — either:
+   - Set `GOOGLE_APPLICATION_CREDENTIALS` to its path (recommended for local dev), **or**
+   - Copy values into `.env`: `project_id` → `FIREBASE_PROJECT_ID`, `client_email` → `FIREBASE_CLIENT_EMAIL`, `private_key` → `FIREBASE_PRIVATE_KEY` (wrap in double quotes, keep all `\n`)
+4. **Never commit** the service-account JSON to GitHub (it is listed in `.gitignore`)
 
 #### Getting a Gemini API Key
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -51,11 +51,13 @@ GEMINI_MODEL_NAME=gemini-2.5-flash
 
 
 # =========================================
-# Firebase Admin SDK
+# Firebase Admin SDK (required for auth — use inline vars OR credentials file)
 # =========================================
 FIREBASE_PROJECT_ID=your_firebase_project_id
 FIREBASE_CLIENT_EMAIL=your_firebase_client_email
 FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n"
+# Alternative: path to downloaded service-account JSON (do not commit the file)
+GOOGLE_APPLICATION_CREDENTIALS=./path/to/firebase-service-account.json
 
 
 # =========================================

--- a/server/index.js
+++ b/server/index.js
@@ -21,14 +21,16 @@ if (isDev) {
 // to avoid failing entirely in environments where optional services (Razorpay)
 // are intentionally not configured (for example: demo deployments on Vercel).
 const CRITICAL_ENV_VARS = ["MONGO_URI"];
+const FIREBASE_INLINE_VARS = [
+  "FIREBASE_PROJECT_ID",
+  "FIREBASE_CLIENT_EMAIL",
+  "FIREBASE_PRIVATE_KEY",
+];
 const OPTIONAL_ENV_VARS = [
   "RAZORPAY_KEY_ID",
   "RAZORPAY_KEY_SECRET",
   "MONGO_DB",
   "PORT",
-  "FIREBASE_PROJECT_ID",
-  "FIREBASE_CLIENT_EMAIL",
-  "FIREBASE_PRIVATE_KEY",
   "SMTP_HOST",
   "SMTP_PORT",
   "SMTP_USER",
@@ -36,6 +38,8 @@ const OPTIONAL_ENV_VARS = [
 ];
 
 const missingCritical = CRITICAL_ENV_VARS.filter((v) => !process.env[v]);
+const hasInlineFirebase = FIREBASE_INLINE_VARS.every((v) => process.env[v]);
+const hasGoogleAppCreds = Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS);
 const missingOptional = OPTIONAL_ENV_VARS.filter((v) => !process.env[v]);
 
 if (missingCritical.length > 0) {
@@ -46,6 +50,15 @@ if (missingCritical.length > 0) {
     "Server cannot start without these. Please set them in your environment.",
   );
   process.exit(1);
+}
+
+if (!hasInlineFirebase && !hasGoogleAppCreds) {
+  console.error(
+    "❌ Firebase Admin credentials missing. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY, or set GOOGLE_APPLICATION_CREDENTIALS to a service-account JSON path.",
+  );
+  console.error(
+    "Authentication and protected API routes will not work until Firebase is configured.",
+  );
 }
 
 if (missingOptional.length > 0) {


### PR DESCRIPTION
## Summary
- Documents `GOOGLE_APPLICATION_CREDENTIALS` in `server/.env.example`
- Treats Firebase as required for auth at startup (error if neither inline vars nor credentials file)
- Aligns README env section with `.env.example` and clarifies optional vs auth-required vars

Closes #94

## Test plan
- [ ] Start server with only `MONGO_URI` — exits as before
- [ ] Start with `MONGO_URI` but no Firebase — logs auth configuration error, continues
- [ ] Start with full `FIREBASE_*` or `GOOGLE_APPLICATION_CREDENTIALS` — no Firebase error