### PR TITLE
refactor(cart): ensureOwnership middleware (#278)

### DIFF
--- a/server/middleware/ensureOwnership.js
+++ b/server/middleware/ensureOwnership.js
@@ -1,0 +1,18 @@
+/**
+ * Ensures the authenticated Firebase UID matches :userId in the route.
+ */
+function ensureOwnership(req, res, next) {
+  if (!req.user?.uid) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.user.uid !== req.params.userId) {
+    return res.status(403).json({
+      error: "Forbidden — you can only access your own resources",
+    });
+  }
+
+  return next();
+}
+
+module.exports = ensureOwnership;

--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const Cart = require('../models/Cart');
 const Product = require('../models/Product');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
+const ensureOwnership = require('../middleware/ensureOwnership');
 
 // Helper: adjust product reserved count
 async function adjustReserved(productId, delta) {
@@ -13,23 +14,12 @@ async function adjustReserved(productId, delta) {
   return prod;
 }
 
-// Helper: check that the token uid matches the userId in the route
-function checkOwnership(req, res) {
-  if (req.user.uid !== req.params.userId) {
-    res.status(403).json({ error: 'Forbidden — you can only access your own cart' });
-    return false;
-  }
-  return true;
-}
-
 /**
  * @route   GET /api/cart/:userId
  * @desc    Get or create a cart for the given user
  * @access  Private
  */
-router.get('/:userId', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.get('/:userId', verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     let cart = await Cart.findOne({ userId });
@@ -47,9 +37,7 @@ router.get('/:userId', verifyFirebaseToken, async (req, res) => {
  * @desc    Add an item to the user's cart and reserve stock; body: { productId, quantity }
  * @access  Private
  */
-router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.post('/:userId/add', verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
@@ -89,9 +77,7 @@ router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
  * @desc    Remove an item (or reduce its quantity) from the user's cart and release reserved stock; body: { productId, quantity }
  * @access  Private
  */
-router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.post('/:userId/remove', verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
@@ -125,9 +111,7 @@ router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
  * @desc    Clear all items from the user's cart and release all reserved stock
  * @access  Private
  */
-router.delete('/:userId', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.delete('/:userId', verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     const cart = await Cart.findOne({ userId });


### PR DESCRIPTION
## Summary
- Extract `ensureOwnership` Express middleware
- Apply to all cart routes; remove inline `checkOwnership` helper

Closes #278

## Test plan
- [ ] Authenticated user can access own cart routes
- [ ] Mismatched `:userId` returns 403
- [ ] Missing token returns 401