### PR TITLE
fix(security): auth middleware on user profile routes (#289)

### DIFF
--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -34,7 +34,10 @@ export default function Checkout() {
         const [cartRes, prodRes, discountRes, profileRes] = await Promise.all([
           fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" }),
           fetch(`${API}/api/products`),
-          fetch(`${API}/api/user/discount-status/${userId}`, { credentials: "include" }),
+          fetch(`${API}/api/user/discount-status/${userId}`, {
+            headers,
+            credentials: "include",
+          }),
           fetch(`${API}/api/user/profile/${userId}`, { headers, credentials: "include" }),
         ]);
 

--- a/server/middleware/ensureOwnership.js
+++ b/server/middleware/ensureOwnership.js
@@ -1,0 +1,18 @@
+/**
+ * Ensures the authenticated Firebase UID matches :userId in the route.
+ */
+function ensureOwnership(req, res, next) {
+  if (!req.user?.uid) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.user.uid !== req.params.userId) {
+    return res.status(403).json({
+      error: "Forbidden — you can only access your own resources",
+    });
+  }
+
+  return next();
+}
+
+module.exports = ensureOwnership;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -6,6 +6,7 @@ const cloudinary = require("../lib/cloudinary");
 const UserProfile = require("../models/UserProfile");
 const admin = require("../firebaseAdmin");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
+const ensureOwnership = require("../middleware/ensureOwnership");
 const router = express.Router();
 
 // Use memory storage for serverless environments
@@ -150,7 +151,11 @@ router.post("/use-discount", async (req, res) => {
 // Returns current discount eligibility for a user.
 // Used by Checkout to decide whether to apply the 10% discount.
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/discount-status/:userId", async (req, res) => {
+router.get(
+  "/discount-status/:userId",
+  verifyFirebaseToken,
+  ensureOwnership,
+  async (req, res) => {
   try {
     const { userId } = req.params;
     const profile = await UserProfile.findOne({ userId });
@@ -175,7 +180,7 @@ router.get("/discount-status/:userId", async (req, res) => {
 // GET /api/user/profile/:userId
 // Returns stored profile (including addresses) for a user
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/profile/:userId", async (req, res) => {
+router.get("/profile/:userId", verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
@@ -195,7 +200,7 @@ router.get("/profile/:userId", async (req, res) => {
 // Body: fields to merge into profile (name, phone, addresses, defaultAddressId)
 // Creates profile if missing.
 // ─────────────────────────────────────────────────────────────────────────────
-router.put("/profile/:userId", async (req, res) => {
+router.put("/profile/:userId", verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
@@ -224,7 +229,12 @@ router.put("/profile/:userId", async (req, res) => {
 // Authenticated endpoint to upload profile photo to Cloudinary
 // Body: multipart form-data with 'photo' field
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/upload-photo/:userId", verifyFirebaseToken, upload.single("photo"), async (req, res) => {
+router.post(
+  "/upload-photo/:userId",
+  verifyFirebaseToken,
+  ensureOwnership,
+  upload.single("photo"),
+  async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });


### PR DESCRIPTION
## Summary
- Add shared `ensureOwnership` middleware (`req.user.uid === :userId`)
- Protect `GET/PUT /profile/:userId`, `GET /discount-status/:userId`, and `POST /upload-photo/:userId` with `verifyFirebaseToken` + ownership check
- Send Firebase auth headers from Checkout when loading discount eligibility

## Test plan
- [ ] Authenticated user can load own profile and discount status on Checkout
- [ ] Request to another user's `userId` returns 403
- [ ] Unauthenticated requests return 401

Closes #289