### PR TITLE
fix(security): secure demo-success payment route (#298)

### DIFF
--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -89,9 +89,10 @@ export default function PaymentPage() {
     setBypassing(true);
     setError(null);
     try {
+      const headers = await getAuthHeaders();
       const res = await fetch(`${API}/api/payment/demo-success`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { ...headers, "Content-Type": "application/json" },
         credentials: "include",
         body: JSON.stringify({ userId: user.uid }),
       });

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -156,12 +156,22 @@ router.post("/clear-cart", verifyFirebaseToken, async (req, res) => {
  * @route   POST /demo-success
  * @desc    Simulates a successful payment for testing only — skips Razorpay, clears cart,
  *          and returns success without creating an order
- * @access  Public (TESTING ONLY) - No authentication required
+ * @access  Private (dev/test) — requires Firebase token; uid must match body.userId
  */
-router.post("/demo-success", async (req, res) => {
+router.post("/demo-success", verifyFirebaseToken, async (req, res) => {
   try {
+    if (process.env.NODE_ENV === "production") {
+      return res.status(404).json({ error: "Not found" });
+    }
+
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId is required" });
+
+    if (req.user.uid !== userId) {
+      return res.status(403).json({
+        error: "Forbidden — you can only complete demo checkout for your own account",
+      });
+    }
 
     // Generate a fake payment ID that looks like a real Razorpay one
     const fakePaymentId = `pay_DEMO_${Date.now()}`;


### PR DESCRIPTION
## Summary
- Require Firebase token on `POST /api/payment/demo-success`
- Reject when `req.user.uid` does not match `body.userId`
- Return 404 in `NODE_ENV=production` so the bypass is not exposed in prod
- Send Bearer token from PaymentPage demo checkout button

## Test plan
- [ ] Demo payment works when logged in (dev)
- [ ] Unauthenticated or mismatched uid returns 401/403
- [ ] Route returns 404 when `NODE_ENV=production`

Closes #298