### PR TITLE
fix(security): Firebase auth on user POST routes (#289)

### DIFF
--- a/server/middleware/ensureBodyUserId.js
+++ b/server/middleware/ensureBodyUserId.js
@@ -1,0 +1,23 @@
+/**
+ * Ensures the authenticated Firebase UID matches userId in the request body.
+ */
+function ensureBodyUserId(req, res, next) {
+  if (!req.user?.uid) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { userId } = req.body;
+  if (!userId) {
+    return res.status(400).json({ error: "userId required" });
+  }
+
+  if (req.user.uid !== userId) {
+    return res.status(403).json({
+      error: "Forbidden — you can only act on your own account",
+    });
+  }
+
+  return next();
+}
+
+module.exports = ensureBodyUserId;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -6,6 +6,7 @@ const cloudinary = require("../lib/cloudinary");
 const UserProfile = require("../models/UserProfile");
 const admin = require("../firebaseAdmin");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
+const ensureBodyUserId = require("../middleware/ensureBodyUserId");
 const router = express.Router();
 
 // Use memory storage for serverless environments
@@ -28,10 +29,9 @@ const upload = multer({
 // - If profile exists and isFirstLogin is false → return showBanner: false
 // Also syncs user email from Firebase to the profile for email sending.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/login", async (req, res) => {
+router.post("/login", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     // Fetch Firebase user to get email and display name
     let firebaseEmail = null;
@@ -98,10 +98,9 @@ router.post("/login", async (req, res) => {
 // Called when user dismisses the welcome banner.
 // Flips isFirstLogin → false so it never shows again.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/dismiss-banner", async (req, res) => {
+router.post("/dismiss-banner", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     await UserProfile.findOneAndUpdate(
       { userId },
@@ -122,10 +121,9 @@ router.post("/dismiss-banner", async (req, res) => {
 // Called after a successful first order.
 // Flips discountUsed → true so it can't be used again.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/use-discount", async (req, res) => {
+router.post("/use-discount", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     const profile = await UserProfile.findOneAndUpdate(
       { userId, discountUsed: false },   // only update if not already used


### PR DESCRIPTION
## Summary
- Add `ensureBodyUserId` middleware (`req.user.uid === body.userId`)
- Apply `verifyFirebaseToken` + ownership check to `POST /login`, `/dismiss-banner`, and `/use-discount`
- Clients (`useWelcomeDiscount`, `PaymentPage`) already send Bearer tokens

## Test plan
- [ ] Logged-in user can still see welcome banner and dismiss it
- [ ] First-order discount flow still marks discount used after payment
- [ ] Spoofed `userId` in body returns 403

Relates to #289