### PR TITLE
fix(ui): landing navbar brand visible on load (#293)

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -50,12 +50,11 @@ export default function Navbar({
   const bgClass = isLanding
     ? navOpaque
       ? "bg-white/95 backdrop-blur-sm border-b border-stone-200 shadow-sm"
-      : "bg-transparent"
+      : "bg-white/80 backdrop-blur-sm border-b border-stone-200/60"
     : "bg-white border-b border-stone-200";
 
-  const logoColor = isLanding && !navOpaque ? "text-white" : "text-stone-900";
-  const iconColor =
-    isLanding && !navOpaque ? "text-white/80 hover:text-white" : "text-stone-500 hover:text-stone-900";
+  const logoColor = "text-stone-900";
+  const iconColor = "text-stone-500 hover:text-stone-900";
 
   const effectiveMenuOpen = typeof setMenuOpen === "function" ? !!menuOpen : localMenuOpen;
 


### PR DESCRIPTION
## Summary
- Dark logo text on landing at all scroll positions
- Subtle `bg-white/80` navbar on initial load instead of fully transparent

Closes #293