### PR TITLE
fix(client): legal page routes and footer links (#252)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,6 +24,8 @@ import NonAdminRoute from "./components/NonAdminRoute";
 import WorkoutNotes from "./pages/NotesPage";
 import WorkoutTracker from "./pages/TrackerPage";
 import ExercisePage from "./pages/ExercisePage";
+import TermsAndConditions from "./pages/TermsAndConditions";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
 
 export default function App() {
   return (
@@ -32,6 +34,8 @@ export default function App() {
         {/* Public routes (redirect admin users to admin dashboard) */}
         <Route path="/" element={<NonAdminRoute><LandingPage /></NonAdminRoute>} />
         <Route path="/auth" element={<Authentication />} />
+        <Route path="/terms" element={<TermsAndConditions />} />
+        <Route path="/privacy-policy" element={<PrivacyPolicy />} />
         <Route path="/home" element={<NonAdminRoute><HomePage /></NonAdminRoute>} />
         <Route path="/product/:productId" element={<NonAdminRoute><ProductPage /></NonAdminRoute>} />
         <Route path="/checkout" element={<NonAdminRoute><Checkout /></NonAdminRoute>} />

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -612,12 +612,26 @@ export default function HomePage() {
           <span className="font-['DM_Serif_Display'] text-lg text-stone-900">FitMart</span>
           <p className="text-xs text-stone-400 text-center">© 2026 FitMart. Built at VESIT, Mumbai.</p>
           <div className="flex gap-4 sm:gap-5">
-            {["Privacy", "Terms", "Support"].map(l => (
-              <button key={l}
-                className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1">
-                {l}
-              </button>
-            ))}
+            <button
+              type="button"
+              onClick={() => navigate("/privacy-policy")}
+              className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1"
+            >
+              Privacy
+            </button>
+            <button
+              type="button"
+              onClick={() => navigate("/terms")}
+              className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1"
+            >
+              Terms
+            </button>
+            <a
+              href="mailto:support@fitmart.com"
+              className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1 inline-flex items-center"
+            >
+              Support
+            </a>
           </div>
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- Register `/terms` and `/privacy-policy` routes in App.jsx
- Wire HomePage footer Privacy/Terms navigation and Support mailto

Relates to #252 (complements PR #300 auth form buttons)

## Test plan
- [ ] Open `/terms` and `/privacy-policy` directly
- [ ] Footer links on `/home` navigate correctly