### PR TITLE
fix(security): uid check on payment create-order

### DIFF
--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -45,6 +45,12 @@ router.post("/create-order", verifyFirebaseToken, async (req, res) => {
     if (!amount || !userId)
       return res.status(400).json({ error: "amount and userId are required" });
 
+    if (req.user.uid !== userId) {
+      return res.status(403).json({
+        error: "Forbidden — you can only create payment orders for your own account",
+      });
+    }
+
     // receipt must be ≤ 40 chars
     const shortId = userId.slice(-8);
     const shortTs = String(Date.now()).slice(-8);


### PR DESCRIPTION
## Summary
- Reject `POST /create-order` when `req.body.userId` does not match `req.user.uid` (403), closing an IDOR vector on Razorpay order creation.

Related to #289 / payment hardening (complements #310 demo-success fix).

## Test plan
- [ ] Authenticated user can create order for own `userId`
- [ ] Request with another user's `userId` returns 403