### PR TITLE
fix(security): uid check on payment verify-payment

### DIFF
--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -77,6 +77,14 @@ router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
     if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature)
       return res.status(400).json({ error: "Missing required payment fields" });
 
+    if (!userId) return res.status(400).json({ error: "userId is required" });
+
+    if (req.user.uid !== userId) {
+      return res.status(403).json({
+        error: "Forbidden — you can only verify payments for your own account",
+      });
+    }
+
     const expected = crypto
       .createHmac("sha256", process.env.RAZORPAY_KEY_SECRET)
       .update(`${razorpay_order_id}|${razorpay_payment_id}`)


### PR DESCRIPTION
## Summary
- Require `userId` in the verify-payment body and return 403 when it does not match `req.user.uid`, preventing IDOR order creation after signature verification.

Related to #298 / #289 payment hardening.

## Test plan
- [ ] Authenticated user can verify payment for own `userId`
- [ ] Mismatched `userId` returns 403 before `createOrder` runs