### PR TITLE
Make Terms and Privacy Policy links clickable using button elements -…

### DIFF
--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -437,8 +437,22 @@ export default function Authentication() {
 
               <p className="text-[11px] text-stone-400 text-center leading-relaxed">
                 By creating an account you agree to our{" "}
-                <span className="underline cursor-pointer">Terms</span> and{" "}
-                <span className="underline cursor-pointer">Privacy Policy</span>.
+                <button
+                  type="button"
+                  onClick={() => navigate("/terms")}
+                  className="underline cursor-pointer"
+                >
+                  Terms
+                </button>
+                {" "}and{" "}
+                <button
+                  type="button"
+                  onClick={() => navigate("/privacy-policy")}
+                  className="underline cursor-pointer"
+                >
+                  Privacy Policy
+                </button>
+                .
               </p>
             </form>
           )}


### PR DESCRIPTION
## 📋 What does this PR do?

Makes the Terms and Privacy Policy links on the Sign Up form clickable.

- Replaced non-interactive `<span>` elements with `<button>` elements
- Added `onClick` handlers to navigate to respective pages:
  - "Terms" → `/terms`
  - "Privacy Policy" → `/privacy-policy`
- Links now properly redirect when clicked

## 🔗 Related Issue

Closes #252

## 🧪 How was this tested?

- Clicked "Terms" link → navigates to `/terms` ✓
- Clicked "Privacy Policy" link → navigates to `/privacy-policy` ✓
- Verified links are properly styled with underline and cursor-pointer

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys