### PR TITLE
fix(user): require auth on profile and account routes

### DIFF
--- a/server/middleware/ensureBodyUserId.js
+++ b/server/middleware/ensureBodyUserId.js
@@ -1,0 +1,23 @@
+/**
+ * Ensures the authenticated Firebase UID matches userId in the request body.
+ */
+function ensureBodyUserId(req, res, next) {
+  if (!req.user?.uid) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const { userId } = req.body;
+  if (!userId) {
+    return res.status(400).json({ error: "userId required" });
+  }
+
+  if (req.user.uid !== userId) {
+    return res.status(403).json({
+      error: "Forbidden — you can only act on your own account",
+    });
+  }
+
+  return next();
+}
+
+module.exports = ensureBodyUserId;

--- a/server/middleware/ensureOwnership.js
+++ b/server/middleware/ensureOwnership.js
@@ -1,0 +1,18 @@
+/**
+ * Ensures the authenticated Firebase UID matches :userId in the route.
+ */
+function ensureOwnership(req, res, next) {
+  if (!req.user?.uid) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  if (req.user.uid !== req.params.userId) {
+    return res.status(403).json({
+      error: "Forbidden — you can only access your own resources",
+    });
+  }
+
+  return next();
+}
+
+module.exports = ensureOwnership;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -6,6 +6,8 @@ const cloudinary = require("../lib/cloudinary");
 const UserProfile = require("../models/UserProfile");
 const admin = require("../firebaseAdmin");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
+const ensureOwnership = require("../middleware/ensureOwnership");
+const ensureBodyUserId = require("../middleware/ensureBodyUserId");
 const router = express.Router();
 
 // Use memory storage for serverless environments
@@ -28,10 +30,9 @@ const upload = multer({
 // - If profile exists and isFirstLogin is false → return showBanner: false
 // Also syncs user email from Firebase to the profile for email sending.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/login", async (req, res) => {
+router.post("/login", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     // Fetch Firebase user to get email and display name
     let firebaseEmail = null;
@@ -98,10 +99,9 @@ router.post("/login", async (req, res) => {
 // Called when user dismisses the welcome banner.
 // Flips isFirstLogin → false so it never shows again.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/dismiss-banner", async (req, res) => {
+router.post("/dismiss-banner", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     await UserProfile.findOneAndUpdate(
       { userId },
@@ -122,10 +122,9 @@ router.post("/dismiss-banner", async (req, res) => {
 // Called after a successful first order.
 // Flips discountUsed → true so it can't be used again.
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/use-discount", async (req, res) => {
+router.post("/use-discount", verifyFirebaseToken, ensureBodyUserId, async (req, res) => {
   try {
     const { userId } = req.body;
-    if (!userId) return res.status(400).json({ error: "userId required" });
 
     const profile = await UserProfile.findOneAndUpdate(
       { userId, discountUsed: false },   // only update if not already used
@@ -150,7 +149,11 @@ router.post("/use-discount", async (req, res) => {
 // Returns current discount eligibility for a user.
 // Used by Checkout to decide whether to apply the 10% discount.
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/discount-status/:userId", async (req, res) => {
+router.get(
+  "/discount-status/:userId",
+  verifyFirebaseToken,
+  ensureOwnership,
+  async (req, res) => {
   try {
     const { userId } = req.params;
     const profile = await UserProfile.findOne({ userId });
@@ -175,7 +178,7 @@ router.get("/discount-status/:userId", async (req, res) => {
 // GET /api/user/profile/:userId
 // Returns stored profile (including addresses) for a user
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/profile/:userId", async (req, res) => {
+router.get("/profile/:userId", verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
@@ -195,7 +198,7 @@ router.get("/profile/:userId", async (req, res) => {
 // Body: fields to merge into profile (name, phone, addresses, defaultAddressId)
 // Creates profile if missing.
 // ─────────────────────────────────────────────────────────────────────────────
-router.put("/profile/:userId", async (req, res) => {
+router.put("/profile/:userId", verifyFirebaseToken, ensureOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
@@ -224,7 +227,12 @@ router.put("/profile/:userId", async (req, res) => {
 // Authenticated endpoint to upload profile photo to Cloudinary
 // Body: multipart form-data with 'photo' field
 // ─────────────────────────────────────────────────────────────────────────────
-router.post("/upload-photo/:userId", verifyFirebaseToken, upload.single("photo"), async (req, res) => {
+router.post(
+  "/upload-photo/:userId",
+  verifyFirebaseToken,
+  ensureOwnership,
+  upload.single("photo"),
+  async (req, res) => {
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });


### PR DESCRIPTION
## Summary
- Add `ensureOwnership` middleware for `:userId` param routes
- Add `ensureBodyUserId` middleware for POST routes with `userId` in body
- Protect login, dismiss-banner, use-discount, profile, discount-status, and upload-photo routes

Fixes #289

## Test plan
- [ ] Unauthenticated GET `/api/user/profile/:userId` returns 401
- [ ] Authenticated request for another user's profile returns 403
- [ ] Authenticated request for own profile succeeds
- [ ] POST `/api/user/login` with mismatched token/body userId returns 403