### PR TITLE
fix(payment): atomically claim welcome discount on verify

### DIFF
--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -64,20 +64,6 @@ export default function PaymentPage() {
       console.error('clear-cart failed:', err);
     }
 
-    if (discountApplied) {
-      try {
-        const headers = await getAuthHeaders();
-        await fetch(`${API}/api/user/use-discount`, {
-          method: "POST",
-          headers,
-          credentials: "include",
-          body: JSON.stringify({ userId }),
-        });
-      } catch (err) {
-        console.error("use-discount error:", err);
-      }
-    }
-
     navigate("/payment-confirmation", {
       state: { items, total, subtotal, discountAmt, discountPercent, discountApplied, paymentId, address },
     });
@@ -89,11 +75,12 @@ export default function PaymentPage() {
     setBypassing(true);
     setError(null);
     try {
+      const headers = await getAuthHeaders();
       const res = await fetch(`${API}/api/payment/demo-success`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers,
         credentials: "include",
-        body: JSON.stringify({ userId: user.uid }),
+        body: JSON.stringify({ userId: user.uid, discountApplied }),
       });
       if (!res.ok) throw new Error("Demo order failed");
       const data = await res.json();
@@ -142,7 +129,7 @@ export default function PaymentPage() {
               method: "POST",
               headers,
               credentials: "include",
-              body: JSON.stringify({ ...response, userId }),
+              body: JSON.stringify({ ...response, userId, discountApplied }),
             });
             if (!verifyRes.ok) throw new Error("Payment verification failed");
             await finishOrder(userId, response.razorpay_payment_id);

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -7,6 +7,7 @@ const router = express.Router();
 
 const Cart = require("../models/Cart");
 const Product = require("../models/Product");
+const UserProfile = require("../models/UserProfile");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
 const { sendFirstPurchaseEmail } = require("../services/firstPurchaseEmailService");
 const { createOrder } = require("../services/orderService");
@@ -72,10 +73,33 @@ router.post("/create-order", verifyFirebaseToken, async (req, res) => {
  */
 router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
   try {
-    const { razorpay_order_id, razorpay_payment_id, razorpay_signature, userId } = req.body;
+    const {
+      razorpay_order_id,
+      razorpay_payment_id,
+      razorpay_signature,
+      userId,
+      discountApplied,
+    } = req.body;
 
     if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature)
       return res.status(400).json({ error: "Missing required payment fields" });
+
+    if (!userId) return res.status(400).json({ error: "userId is required" });
+
+    if (req.user.uid !== userId) {
+      return res.status(403).json({
+        error: "Forbidden — you can only verify payment for your own account",
+      });
+    }
+
+    if (discountApplied) {
+      const profile = await claimWelcomeDiscount(userId);
+      if (!profile) {
+        return res.status(400).json({
+          error: "Welcome discount already used or not available",
+        });
+      }
+    }
 
     const expected = crypto
       .createHmac("sha256", process.env.RAZORPAY_KEY_SECRET)
@@ -160,8 +184,17 @@ router.post("/clear-cart", verifyFirebaseToken, async (req, res) => {
  */
 router.post("/demo-success", async (req, res) => {
   try {
-    const { userId } = req.body;
+    const { userId, discountApplied } = req.body;
     if (!userId) return res.status(400).json({ error: "userId is required" });
+
+    if (discountApplied) {
+      const profile = await claimWelcomeDiscount(userId);
+      if (!profile) {
+        return res.status(400).json({
+          error: "Welcome discount already used or not available",
+        });
+      }
+    }
 
     // Generate a fake payment ID that looks like a real Razorpay one
     const fakePaymentId = `pay_DEMO_${Date.now()}`;


### PR DESCRIPTION
## Summary
- Atomically claim welcome discount with findOneAndUpdate during payment verify
- Prevent concurrent checkouts from applying the discount multiple times
- Remove separate client-side use-discount call

Fixes #257

## Test plan
- [ ] First order with discount applies once
- [ ] Concurrent verify requests cannot double-apply discount