### PR TITLE
fix(auth): link Terms and Privacy Policy on sign-up form

### DIFF
--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -437,8 +437,22 @@ export default function Authentication() {
 
               <p className="text-[11px] text-stone-400 text-center leading-relaxed">
                 By creating an account you agree to our{" "}
-                <span className="underline cursor-pointer">Terms</span> and{" "}
-                <span className="underline cursor-pointer">Privacy Policy</span>.
+                <button
+                  type="button"
+                  onClick={() => navigate("/terms")}
+                  className="underline text-stone-500 hover:text-stone-700"
+                >
+                  Terms
+                </button>{" "}
+                and{" "}
+                <button
+                  type="button"
+                  onClick={() => navigate("/privacy-policy")}
+                  className="underline text-stone-500 hover:text-stone-700"
+                >
+                  Privacy Policy
+                </button>
+                .
               </p>
             </form>
           )}


### PR DESCRIPTION
## Summary
- Replace non-clickable Terms/Privacy spans with navigation buttons
- Link to `/terms` and `/privacy-policy` routes

Fixes #252

## Test plan
- [ ] On sign-up form, Terms opens terms page
- [ ] Privacy Policy opens privacy policy page