### PR TITLE
fix(ui): keep FitMart brand visible on landing navbar load

### DIFF
--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -50,12 +50,11 @@ export default function Navbar({
   const bgClass = isLanding
     ? navOpaque
       ? "bg-white/95 backdrop-blur-sm border-b border-stone-200 shadow-sm"
-      : "bg-transparent"
+      : "bg-white/80 backdrop-blur-sm border-b border-stone-200/60"
     : "bg-white border-b border-stone-200";
 
-  const logoColor = isLanding && !navOpaque ? "text-white" : "text-stone-900";
-  const iconColor =
-    isLanding && !navOpaque ? "text-white/80 hover:text-white" : "text-stone-500 hover:text-stone-900";
+  const logoColor = "text-stone-900";
+  const iconColor = "text-stone-500 hover:text-stone-900";
 
   const effectiveMenuOpen = typeof setMenuOpen === "function" ? !!menuOpen : localMenuOpen;
 


### PR DESCRIPTION
## Summary
- Use subtle translucent navbar background before scroll instead of fully transparent
- Keep logo and icons dark so FitMart brand is visible on light hero background

Fixes #293

## Test plan
- [ ] Load landing page — FitMart brand readable without scrolling
- [ ] Navbar still transitions correctly after scroll if applicable