### PR TITLE
fix(inventory): unify low-stock threshold across API and dashboard

### DIFF
--- a/client/src/constants/inventory.js
+++ b/client/src/constants/inventory.js
@@ -1,0 +1,1 @@
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 
-const LOW_STOCK_THRESHOLD = 5;
+import { LOW_STOCK_THRESHOLD } from "../constants/inventory";
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -16,6 +16,7 @@ APP_BASE_URL=http://localhost:5173
 # For MongoDB Atlas, use your connection string
 MONGO_URI=mongodb://localhost:27017
 MONGO_DB=FitMart
+LOW_STOCK_THRESHOLD=5
 
 
 # =========================================

--- a/server/constants/inventory.js
+++ b/server/constants/inventory.js
@@ -1,0 +1,10 @@
+const LOW_STOCK_THRESHOLD = Number.parseInt(
+  process.env.LOW_STOCK_THRESHOLD,
+  10,
+);
+
+module.exports = {
+  LOW_STOCK_THRESHOLD: Number.isFinite(LOW_STOCK_THRESHOLD)
+    ? LOW_STOCK_THRESHOLD
+    : 5,
+};

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -6,6 +6,7 @@ const Product = require('../models/Product');
 const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
+const { LOW_STOCK_THRESHOLD } = require('../constants/inventory');
 
 // ── Helper: resolve Firebase UID → { displayName, email } ─────────────────
 // Returns "—" gracefully if user is deleted or UID is invalid
@@ -64,10 +65,10 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
-    const lowStockCount = await Product.countDocuments({
-      stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
-    });
+    const stockedProducts = await Product.find({ stock: { $ne: null } });
+    const lowStockCount = stockedProducts.filter(
+      (p) => (p.stock - (p.reserved || 0)) < LOW_STOCK_THRESHOLD,
+    ).length;
 
     // ── 4. Chart: Revenue Over Time ───────────────────────────────────────
     const revenueGroupFormat =

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Product = require('../models/Product');
+const { LOW_STOCK_THRESHOLD } = require('../constants/inventory');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 
@@ -24,8 +25,6 @@ router.get('/', async (req, res) => {
  * @access  Public
  */
 // GET /api/products/low-stock - get products with low stock
-const LOW_STOCK_THRESHOLD = 5;
-
 router.get('/low-stock', async (req, res) => {
   try {
     // only check products where stock is not null


### PR DESCRIPTION
## Summary
- Centralize `LOW_STOCK_THRESHOLD` in shared constants (env-configurable on server)
- Align dashboard low-stock KPI with products API and admin inventory UI

Fixes #242

## Test plan
- [ ] Low-stock products consistent between `/api/products/low-stock`, dashboard KPI, and admin inventory
- [ ] `LOW_STOCK_THRESHOLD` env var overrides default when set