### PR TITLE
fix: protect user profile routes with auth checks

### DIFF
--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -34,7 +34,7 @@ export default function Checkout() {
         const [cartRes, prodRes, discountRes, profileRes] = await Promise.all([
           fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" }),
           fetch(`${API}/api/products`),
-          fetch(`${API}/api/user/discount-status/${userId}`, { credentials: "include" }),
+          fetch(`${API}/api/user/discount-status/${userId}`, { headers, credentials: "include" }),
           fetch(`${API}/api/user/profile/${userId}`, { headers, credentials: "include" }),
         ]);
 

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -19,6 +19,14 @@ const upload = multer({
   },
 });
 
+function checkOwnership(req, res) {
+  if (req.user.uid !== req.params.userId) {
+    res.status(403).json({ error: "Forbidden" });
+    return false;
+  }
+  return true;
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/user/login
 // Body: { userId }
@@ -150,7 +158,9 @@ router.post("/use-discount", async (req, res) => {
 // Returns current discount eligibility for a user.
 // Used by Checkout to decide whether to apply the 10% discount.
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/discount-status/:userId", async (req, res) => {
+router.get("/discount-status/:userId", verifyFirebaseToken, async (req, res) => {
+  if (!checkOwnership(req, res)) return;
+
   try {
     const { userId } = req.params;
     const profile = await UserProfile.findOne({ userId });
@@ -175,7 +185,9 @@ router.get("/discount-status/:userId", async (req, res) => {
 // GET /api/user/profile/:userId
 // Returns stored profile (including addresses) for a user
 // ─────────────────────────────────────────────────────────────────────────────
-router.get("/profile/:userId", async (req, res) => {
+router.get("/profile/:userId", verifyFirebaseToken, async (req, res) => {
+  if (!checkOwnership(req, res)) return;
+
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
@@ -195,7 +207,9 @@ router.get("/profile/:userId", async (req, res) => {
 // Body: fields to merge into profile (name, phone, addresses, defaultAddressId)
 // Creates profile if missing.
 // ─────────────────────────────────────────────────────────────────────────────
-router.put("/profile/:userId", async (req, res) => {
+router.put("/profile/:userId", verifyFirebaseToken, async (req, res) => {
+  if (!checkOwnership(req, res)) return;
+
   try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });


### PR DESCRIPTION
## 📝 What does this PR do?

- Added `verifyFirebaseToken` protection to user profile routes
- Added ownership validation for:
  - `GET /api/user/profile/:userId`
  - `PUT /api/user/profile/:userId`
  - `GET /api/user/discount-status/:userId`
- Prevented authenticated users from accessing/modifying another user's profile data
- Ensured frontend profile-related requests include Firebase auth tokens
- Reused the existing auth/ownership pattern already used in cart routes

## 🔗 Related Issue

Closes #289

## 🧪 How was this tested?

- Ran available backend/frontend scripts locally
- Verified unauthenticated profile requests are rejected
- Verified authenticated users can access their own profile
- Verified authenticated users cannot access another user's profile
- Confirmed Profile page still loads correctly
- Confirmed Checkout profile/address fetch still works
- Confirmed Firebase auth token is included in protected requests

## 📸 Screenshots (if UI changes)

No UI changes.

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys