### PR TITLE
refactor(client): centralize API calls in shared apiClient (#274)

### DIFF
--- a/client/src/auth/useWelcomeDiscount.js
+++ b/client/src/auth/useWelcomeDiscount.js
@@ -1,8 +1,7 @@
 // src/auth/useWelcomeDiscount.js
 import { useState, useEffect, useRef } from "react";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 export function useWelcomeDiscount(user) {
   const [showBanner, setShowBanner] = useState(false);
@@ -16,11 +15,7 @@ export function useWelcomeDiscount(user) {
 
     (async () => {
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/user/login`, {
-          method: "POST",
-          headers,
-          credentials: "include",
+        const res = await apiFetch(`user/login`, { auth: true, method: "POST",
           body: JSON.stringify({ userId: user.uid }),
         });
         if (!res.ok) return;
@@ -40,11 +35,7 @@ export function useWelcomeDiscount(user) {
     setShowBanner(false);
     if (!user) return;
     try {
-      const headers = await getAuthHeaders();
-      await fetch(`${API}/api/user/dismiss-banner`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+      await apiFetch(`user/dismiss-banner`, { auth: true, method: "POST",
         body: JSON.stringify({ userId: user.uid }),
       });
     } catch (err) {

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -1,7 +1,7 @@
 // src/components/FitnessChatBot.jsx
 import { useState, useEffect, useRef } from "react";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 const WELCOME = {
   role: "bot",
@@ -47,7 +47,7 @@ export default function FitnessChatBot() {
     setInput("");
     setTyping(true);
     try {
-      const res = await fetch(`${API}/api/chat`, {
+      const res = await apiFetch(`chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: text }),

--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessCenterDetail from "./FitnessCenterDetail";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 function Stars({ rating = 0 }) {
   const full = Math.floor(rating || 0);
@@ -34,9 +33,8 @@ export default function NearbyFitnessCenters({ visible = true }) {
     (async () => {
       setLoading(true);
       try {
-        const headers = await getAuthHeaders();
         const q = filter && filter !== "all" ? `?type=${filter}` : "";
-        const res = await fetch(`${API}/api/fitness-centers/nearby${q}`, { headers, credentials: "include" });
+        const res = await apiFetch(`fitness-centers/nearby${q}`, { auth: true });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setCenters(data.slice(0, 5));

--- a/client/src/components/ReportBugButton.jsx
+++ b/client/src/components/ReportBugButton.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../auth/useAuth';
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
 const CATEGORIES = [
   { id: 'bug',     label: 'Bug' },
@@ -248,7 +248,7 @@ export default function ReportBugButton() {
         });
       }
 
-      const res = await fetch(`${API}/api/bugs`, { method: 'POST', headers, body });
+      const res = await apiFetch(`bugs`, { method: 'POST', headers, body });
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error(data?.error || 'Server error. Please try again.');

--- a/client/src/lib/apiClient.js
+++ b/client/src/lib/apiClient.js
@@ -1,0 +1,47 @@
+import { getAuthHeaders } from "../utils/getAuthHeaders";
+
+const DEFAULT_BASE_URL = "http://localhost:5000";
+
+export const API_BASE_URL = (
+  import.meta.env.VITE_API_URL || DEFAULT_BASE_URL
+).replace(/\/$/, "");
+
+/** Build a full API URL from a path like `/products` or `cart/uid`. */
+export function apiUrl(path = "") {
+  let normalized = path.startsWith("/") ? path : `/${path}`;
+  if (!normalized.startsWith("/api")) {
+    normalized = `/api${normalized}`;
+  }
+  return `${API_BASE_URL}${normalized}`;
+}
+
+/**
+ * Fetch wrapper with optional Firebase auth headers.
+ * @param {string} path API path or absolute URL
+ * @param {RequestInit & { auth?: boolean }} options
+ */
+export async function apiFetch(path, options = {}) {
+  const { auth = false, headers: initHeaders, ...rest } = options;
+  const url = path.startsWith("http") ? path : apiUrl(path);
+
+  let headers = initHeaders;
+  if (auth) {
+    const authHeaders = await getAuthHeaders();
+    if (rest.body instanceof FormData) {
+      headers = {
+        ...(authHeaders.Authorization
+          ? { Authorization: authHeaders.Authorization }
+          : {}),
+        ...(initHeaders || {}),
+      };
+    } else {
+      headers = { ...authHeaders, ...(initHeaders || {}) };
+    }
+  }
+
+  return fetch(url, {
+    credentials: "include",
+    ...rest,
+    headers,
+  });
+}

--- a/client/src/pages/AdminBugs.jsx
+++ b/client/src/pages/AdminBugs.jsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import AdminNavbar from '../components/AdminNavbar';
 import { useAuth } from '../auth/useAuth';
+import { apiFetch, API_BASE_URL } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
 const SEGMENT_STYLES = {
   open: "bg-stone-900 text-white",
@@ -99,17 +99,15 @@ export default function AdminBugs() {
     // optimistic update
     setBugs((cur) => cur.map(b => (b._id === id ? { ...b, status: newStatus } : b)));
     try {
-      const token = await user.getIdToken();
-      const url = `${API}/api/bugs/${id}`;
-      const res = await fetch(url, {
+      const res = await apiFetch(`/bugs/${id}`, {
+        auth: true,
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({ status: newStatus }),
       });
       if (!res.ok) {
         let body = null;
         try { body = await res.json(); } catch (e) { body = await res.text(); }
-        console.error('PATCH failed', { url, status: res.status, body });
+        console.error('PATCH failed', { id, status: res.status, body });
         throw new Error(`update failed (${res.status})`);
       }
       setMobilePicker(null);
@@ -127,8 +125,7 @@ export default function AdminBugs() {
     setLoadingBugs(true);
     (async () => {
       try {
-        const token = await user.getIdToken();
-        const res = await fetch(`${API}/api/bugs`, { headers: { Authorization: `Bearer ${token}` } });
+        const res = await apiFetch(`/bugs`, { auth: true });
         if (!res.ok) throw new Error('Failed to fetch');
         const body = await res.json();
         if (mounted) setBugs(body.bugs || []);
@@ -383,16 +380,15 @@ export default function AdminBugs() {
                             bug.status = newStatus;
                             setBugs((cur) => cur.map(b => (b._id === bug._id ? { ...b, status: newStatus } : b)));
                             try {
-                              const token = await user.getIdToken();
-                              const res = await fetch(`${API}/api/bugs/${bug._id}`, {
+                              const res = await apiFetch(`/bugs/${bug._id}`, {
+                                auth: true,
                                 method: 'PATCH',
-                                headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
                                 body: JSON.stringify({ status: newStatus }),
                               });
                               if (!res.ok) {
                                 let body = null;
                                 try { body = await res.json(); } catch (e) { body = await res.text(); }
-                                console.error('PATCH failed', { url: `${API}/api/bugs/${bug._id}`, status: res.status, body });
+                                console.error('PATCH failed', { id: bug._id, status: res.status, body });
                                 throw new Error(`update failed (${res.status})`);
                               }
                             } catch (err) {
@@ -431,8 +427,7 @@ export default function AdminBugs() {
                     <td className="px-6 py-5 text-center">
                       {(bug.screenshotUrl || bug.screenshot) ? (
                         (() => {
-                          const api = import.meta.env.VITE_API_URL || 'http://localhost:5000';
-                          const url = bug.screenshotUrl ? bug.screenshotUrl : `${api}${bug.screenshot}`;
+                          const url = bug.screenshotUrl ? bug.screenshotUrl : `${API_BASE_URL}${bug.screenshot}`;
                           return (
                             <a
                               href={url}

--- a/client/src/pages/AdminCustomerDetail.jsx
+++ b/client/src/pages/AdminCustomerDetail.jsx
@@ -3,9 +3,8 @@ import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { fmt } from "../utils/formatters";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 
-const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const SEGMENT_STYLES = {
   "high-value": "bg-stone-900 text-white",
@@ -144,8 +143,7 @@ export default function AdminCustomerDetail() {
   useEffect(() => {
     (async () => {
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API_BASE}/customers/${userId}`, { headers });
+        const res = await apiFetch(`customers/${userId}`, { auth: true });
         const json = await res.json();
         if (!json.success) throw new Error(json.error || "Failed to load customer");
         setData(json.data);
@@ -166,7 +164,7 @@ export default function AdminCustomerDetail() {
     if (ids.length === 0) return;
     const map = {};
     Promise.all(ids.map(id =>
-      fetch(`${API_BASE}/products/${id}`).then(r => r.ok ? r.json() : null)
+      apiFetch(`products/${id}`).then(r => r.ok ? r.json() : null)
         .then(p => { if (p) map[id] = p; })
         .catch(() => { })
     )).then(() => setProductMap(map));
@@ -179,9 +177,7 @@ export default function AdminCustomerDetail() {
       // Try to fetch saved profile/address for the user to include in invoice
       let profileAddrHtml = "";
       try {
-        const root = API_BASE.replace(/\/api$/, "");
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${root}/api/user/profile/${userId}`, { headers });
+        const res = await apiFetch(`user/profile/${userId}`, { auth: true });
         if (res.ok) {
           const p = await res.json();
           const addr = (p?.addresses || []).find(a => a.id === p?.defaultAddressId) || (p?.addresses || [])[0];
@@ -245,11 +241,7 @@ export default function AdminCustomerDetail() {
     setSendingReminder(true);
     setReminderError(null);
     try {
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API_BASE}/customers/${userId}/send-reminder`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+      const res = await apiFetch(`customers/${userId}/send-reminder`, { auth: true, method: "POST",
       });
       const resData = await res.json();
       if (!res.ok) {

--- a/client/src/pages/AdminCustomers.jsx
+++ b/client/src/pages/AdminCustomers.jsx
@@ -2,10 +2,9 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { fmt } from "../utils/formatters";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import AdminNavbar from "../components/AdminNavbar";
+import { apiFetch } from "../lib/apiClient";
 
-const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const SEGMENT_STYLES = {
   "high-value": "bg-stone-900 text-white",
@@ -126,8 +125,7 @@ export default function AdminCustomers() {
   useEffect(() => {
     (async () => {
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API_BASE}/customers`, { headers });
+        const res = await apiFetch(`customers`, { auth: true });
         const json = await res.json();
         if (!json.success) {
           throw new Error(json.error || "Failed to load customers");
@@ -148,11 +146,7 @@ export default function AdminCustomers() {
     setSendingReminderId(customerId);
 
     try {
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API_BASE}/customers/${customerId}/send-reminder`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+      const res = await apiFetch(`customers/${customerId}/send-reminder`, { auth: true, method: "POST",
       });
 
       const data = await res.json();

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -1,7 +1,7 @@
 // src/pages/AdminDashboard.jsx
 import { useState, useEffect } from "react";
 import AdminNavbar from "../components/AdminNavbar";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 import {
   AreaChart, Area,
   BarChart, Bar,
@@ -10,7 +10,6 @@ import {
   ResponsiveContainer,
 } from "recharts";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 const fmt = (n) =>
   new Intl.NumberFormat("en-IN", {
@@ -142,8 +141,7 @@ export default function AdminDashboard() {
       setLoading(true);
       setError(null);
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API_BASE}/api/dashboard?range=${range}`, { headers });
+        const res = await apiFetch(`/dashboard?range=${range}`, { auth: true });
         if (!res.ok) throw new Error("Failed to fetch dashboard data");
         setData(await res.json());
       } catch (err) {

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -2,10 +2,9 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 
 const LOW_STOCK_THRESHOLD = 5;
-const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {
   const isUnavailable = p.stock === null;
@@ -124,8 +123,7 @@ export default function AdminInventory() {
   const fetchProducts = async () => {
     setLoading(true);
     try {
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API_BASE}/products`, { headers });
+      const res = await apiFetch(`products`, { auth: true });
       const data = await res.json();
       setProducts(data);
       setLoading(false);
@@ -201,11 +199,7 @@ export default function AdminInventory() {
         }
       }
 
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API_BASE}/products/${id}`, {
-        method: 'PUT',
-        headers,
-        body: JSON.stringify(payload),
+      const res = await apiFetch(`products/${id}`, { auth: true, method: 'PUT', body: JSON.stringify(payload),
       });
       if (!res.ok) {
         const errBody = await res.json().catch(() => ({}));

--- a/client/src/pages/AdminReports.jsx
+++ b/client/src/pages/AdminReports.jsx
@@ -3,9 +3,8 @@ import { useState, useEffect } from "react";
 import { fmt } from "../utils/formatters";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 
-const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const RANGE_LABELS = {
   daily: "Last 24 Hours",
@@ -89,8 +88,7 @@ export default function AdminReports() {
       setLoading(true);
       setError(null);
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API_BASE}/reports/sales?range=${range}`, { headers });
+        const res = await apiFetch(`reports/sales?range=${range}`, { auth: true });
         const json = await res.json();
         setData(json);
         setLoading(false);
@@ -110,7 +108,7 @@ export default function AdminReports() {
     if (ids.length === 0) return;
     const map = {};
     Promise.all(ids.map(id =>
-      fetch(`${API_BASE}/products/${id}`).then(r => r.ok ? r.json() : null)
+      apiFetch(`products/${id}`).then(r => r.ok ? r.json() : null)
         .then(p => { if (p) map[id] = p; })
         .catch(() => { })
     )).then(() => setProductMap(map));

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -4,10 +4,9 @@ import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { fmt } from "../utils/formatters";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 export default function Checkout() {
   const navigate = useNavigate();
@@ -29,13 +28,11 @@ export default function Checkout() {
       const userId = user.uid;
 
       try {
-        const headers = await getAuthHeaders();
-
         const [cartRes, prodRes, discountRes, profileRes] = await Promise.all([
-          fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" }),
-          fetch(`${API}/api/products`),
-          fetch(`${API}/api/user/discount-status/${userId}`, { credentials: "include" }),
-          fetch(`${API}/api/user/profile/${userId}`, { headers, credentials: "include" }),
+          apiFetch(`cart/${userId}`, { auth: true }),
+          apiFetch(`products`),
+          apiFetch(`user/discount-status/${userId}`, { credentials: "include" }),
+          apiFetch(`user/profile/${userId}`, { auth: true }),
         ]);
 
         if (!cartRes.ok) throw new Error("Failed to fetch cart");

--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import { addExerciseToWorkout, getWorkoutByDate } from "../utils/workoutStorage";
+import { apiFetch } from "../lib/apiClient";
 
 const CATEGORIES = [
   { id: "chest", name: "Chest" },
@@ -50,8 +51,7 @@ export default function ExercisePage() {
     setImageErrors(new Set());
 
     try {
-      const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:5000";
-      const response = await fetch(`${apiUrl}/api/exercises/${bodyPart}`);
+      const response = await apiFetch(`/exercises/${bodyPart}`);
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -6,7 +6,6 @@ import { signOut } from "firebase/auth";
 import { auth } from "../auth/firebase";
 import CartDrawer from "../components/CartDrawer";
 import { fmt } from "../utils/formatters";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessChatBot from "../components/FitnessChatBot";
 import WelcomeBanner from "../components/WelcomeBanner";
 import { useWelcomeDiscount } from "../auth/useWelcomeDiscount";
@@ -16,10 +15,10 @@ import NearbyFitnessCenters from "../components/NearbyFitnessCenters";
 import Stars from "../components/Stars";
 import ProductCardSkeleton from "../components/ProductCardSkeleton";
 import CategoryPillsSkeleton from "../components/CategoryPillsSkeleton";
+import { apiFetch } from "../lib/apiClient";
 
 
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 const CATEGORIES = [
   { name: "All", value: "all" },
@@ -214,7 +213,7 @@ export default function HomePage() {
       setLoading(true);
       setBackendError(false);
       try {
-        const res = await fetch(`${API}/api/products`);
+        const res = await apiFetch(`products`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setProducts(data.map(p => ({ ...p, id: p.productId || p.id })));
@@ -232,8 +231,7 @@ export default function HomePage() {
     if (!user || !products.length) return;
     (async () => {
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/cart/${user.uid}`, { headers, credentials: "include" });
+        const res = await apiFetch(`cart/${user.uid}`, { auth: true });
         if (!res.ok) return;
         const cartDoc = await res.json();
         setCart(mapCart(cartDoc, products));
@@ -255,9 +253,7 @@ export default function HomePage() {
   const addToCart = async (product) => {
     if (!user) return;
     try {
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/add`, {
-        method: "POST", headers, credentials: "include",
+      const res = await apiFetch(`cart/${user.uid}/add`, { auth: true, method: "POST",
         body: JSON.stringify({ productId: product.productId || product.id, quantity: 1 }),
       });
       if (!res.ok) throw new Error("Failed to add to cart");
@@ -270,9 +266,7 @@ export default function HomePage() {
     if (!user) return;
     try {
       const existing = cart.find(i => i.id === id);
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
-        method: "POST", headers, credentials: "include",
+      const res = await apiFetch(`cart/${user.uid}/remove`, { auth: true, method: "POST",
         body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
       });
       if (!res.ok) throw new Error("Failed to remove");
@@ -285,12 +279,10 @@ export default function HomePage() {
     if (!user) return;
     try {
       const url = delta > 0 ? "add" : "remove";
-      const headers = await getAuthHeaders();
-      await fetch(`${API}/api/cart/${user.uid}/${url}`, {
-        method: "POST", headers, credentials: "include",
+      await apiFetch(`cart/${user.uid}/${url}`, { auth: true, method: "POST",
         body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
       });
-      const res = await fetch(`${API}/api/cart/${user.uid}`, { headers, credentials: "include" });
+      const res = await apiFetch(`cart/${user.uid}`, { auth: true });
       const cartDoc = await res.json();
       setCart(mapCart(cartDoc, products));
     } catch (err) { console.error("Update qty failed:", err); }

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -5,7 +5,7 @@ import Navbar from "../components/Navbar";
 import { auth } from "../auth/firebase";
 import { fmt } from "../utils/formatters";
 import { useGithubStats } from "../utils/useGithubStats";
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+import { apiFetch } from "../lib/apiClient";
 
 const formatStat = (n, loading) => (loading ? "—" : Number(n).toLocaleString("en-IN"));
 
@@ -131,7 +131,7 @@ export default function LandingPage() {
       setLoadingProducts(true);
       setBackendError(false);
       try {
-        const res = await fetch(`${API}/api/products`);
+        const res = await apiFetch(`products`);
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json();
         setProducts(data.map(p => ({ ...p, id: p.productId || p.id })));

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -2,10 +2,9 @@
 import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 const RAZORPAY_KEY = import.meta.env.VITE_RAZORPAY_KEY_ID;
 
 function useRazorpayScript() {
@@ -53,11 +52,7 @@ export default function PaymentPage() {
 
   const finishOrder = async (userId, paymentId) => {
     try {
-      const headers = await getAuthHeaders();
-      await fetch(`${API}/api/payment/clear-cart`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+      await apiFetch(`payment/clear-cart`, { auth: true, method: "POST",
         body: JSON.stringify({ userId }),
       });
     } catch (err) {
@@ -66,11 +61,7 @@ export default function PaymentPage() {
 
     if (discountApplied) {
       try {
-        const headers = await getAuthHeaders();
-        await fetch(`${API}/api/user/use-discount`, {
-          method: "POST",
-          headers,
-          credentials: "include",
+        await apiFetch(`user/use-discount`, { auth: true, method: "POST",
           body: JSON.stringify({ userId }),
         });
       } catch (err) {
@@ -89,10 +80,9 @@ export default function PaymentPage() {
     setBypassing(true);
     setError(null);
     try {
-      const res = await fetch(`${API}/api/payment/demo-success`, {
+      const res = await apiFetch(`/payment/demo-success`, {
+        auth: true,
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        credentials: "include",
         body: JSON.stringify({ userId: user.uid }),
       });
       if (!res.ok) throw new Error("Demo order failed");
@@ -113,11 +103,7 @@ export default function PaymentPage() {
     setError(null);
 
     try {
-      const headers = await getAuthHeaders();
-      const orderRes = await fetch(`${API}/api/payment/create-order`, {
-        method: "POST",
-        headers,
-        credentials: "include",
+      const orderRes = await apiFetch(`payment/create-order`, { auth: true, method: "POST",
         body: JSON.stringify({ amount: total, currency: "INR", userId }),
       });
       if (!orderRes.ok) {
@@ -137,11 +123,7 @@ export default function PaymentPage() {
         theme: { color: "#1c1917" },
         handler: async (response) => {
           try {
-            const headers = await getAuthHeaders();
-            const verifyRes = await fetch(`${API}/api/payment/verify-payment`, {
-              method: "POST",
-              headers,
-              credentials: "include",
+            const verifyRes = await apiFetch(`payment/verify-payment`, { auth: true, method: "POST",
               body: JSON.stringify({ ...response, userId }),
             });
             if (!verifyRes.ok) throw new Error("Payment verification failed");

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -2,12 +2,11 @@
 import { useState, useEffect, useRef } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import { fmt } from "../utils/formatters";
 import CartDrawer from "../components/CartDrawer";
 import Stars from "../components/Stars";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 const FEATURE_MAP = {
   Equipment: ["Free shipping", "Assembly guide included", "2-year warranty", "Returns within 30 days"],
@@ -16,9 +15,7 @@ const FEATURE_MAP = {
 };
 
 async function apiAddToCart(userId, productId, quantity) {
-  const headers = await getAuthHeaders();
-  const res = await fetch(`${API}/api/cart/${userId}/add`, {
-    method: "POST", headers, credentials: "include",
+  const res = await apiFetch(`cart/${userId}/add`, { auth: true, method: "POST",
     body: JSON.stringify({ productId, quantity }),
   });
   if (!res.ok) throw new Error("Failed to add to cart");
@@ -26,8 +23,7 @@ async function apiAddToCart(userId, productId, quantity) {
 }
 
 async function apiGetCart(userId) {
-  const headers = await getAuthHeaders();
-  const res = await fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" });
+  const res = await apiFetch(`cart/${userId}`, { auth: true });
   if (!res.ok) throw new Error("Failed to fetch cart");
   return res.json();
 }
@@ -97,7 +93,7 @@ export default function ProductPage() {
       setLoading(true);
       setError(null);
       try {
-        const res = await fetch(`${API}/api/products`);
+        const res = await apiFetch(`products`);
         if (!res.ok) throw new Error("Failed to load products");
         const all = res.ok ? await res.json() : [];
         const normalised = all.map(p => ({ ...p, id: p.productId }));
@@ -162,9 +158,7 @@ export default function ProductPage() {
     if (!user) return;
     try {
       const existing = cart.find(i => i.id === id);
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
-        method: "POST", headers, credentials: "include",
+      const res = await apiFetch(`cart/${user.uid}/remove`, { auth: true, method: "POST",
         body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
       });
       if (!res.ok) throw new Error("Failed to remove");
@@ -180,9 +174,7 @@ export default function ProductPage() {
     if (!user) return;
     try {
       const url = delta > 0 ? "add" : "remove";
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/${url}`, {
-        method: "POST", headers, credentials: "include",
+      const res = await apiFetch(`cart/${user.uid}/${url}`, { auth: true, method: "POST",
         body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
       });
       if (!res.ok) throw new Error("Failed to update qty");

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -3,10 +3,9 @@ import { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
-import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 function Toast({ message, onClose }) {
   useEffect(() => {
@@ -130,8 +129,7 @@ export default function Profile() {
       setPhotoURL(user.photoURL);
       setLoading(true);
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/user/profile/${user.uid}`, { headers, credentials: "include" });
+        const res = await apiFetch(`user/profile/${user.uid}`, { auth: true });
         if (!res.ok) throw new Error("Failed to load profile");
         const data = await res.json();
         setProfile({
@@ -163,8 +161,7 @@ export default function Profile() {
       
       setLoadingOrders(true);
       try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/orders/${user.uid}`, { headers, credentials: "include" });
+        const res = await apiFetch(`orders/${user.uid}`, { auth: true });
         if (!res.ok) throw new Error("Failed to load orders");
         const data = await res.json();
         setOrders(Array.isArray(data) ? data : []);
@@ -185,11 +182,7 @@ export default function Profile() {
     setError(null);
     setSaving(true);
     try {
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/user/profile/${user.uid}`, {
-        method: "PUT",
-        headers,
-        credentials: "include",
+      const res = await apiFetch(`user/profile/${user.uid}`, { auth: true, method: "PUT",
         body: JSON.stringify({
           name: profile.name,
           phone: profile.phone,
@@ -223,13 +216,9 @@ export default function Profile() {
       const formData = new FormData();
       formData.append("photo", file);
 
-      const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/user/upload-photo/${user.uid}`, {
+      const res = await apiFetch(`/user/upload-photo/${user.uid}`, {
+        auth: true,
         method: "POST",
-        headers: {
-          "Authorization": headers.Authorization,
-        },
-        credentials: "include",
         body: formData,
       });
 

--- a/client/src/utils/workoutStorage.js
+++ b/client/src/utils/workoutStorage.js
@@ -1,14 +1,12 @@
-import { getAuthHeaders } from "./getAuthHeaders";
+import { apiFetch } from "../lib/apiClient";
 
-const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 /**
  * Retrieves all stored workout logs from the backend.
  */
 export const getWorkoutLogs = async () => {
   try {
-    const headers = await getAuthHeaders();
-    const res = await fetch(`${API}/api/workouts`, { headers });
+    const res = await apiFetch(`workouts`, { auth: true });
     if (!res.ok) throw new Error("Failed to fetch workouts");
     return await res.json();
   } catch (err) {
@@ -36,11 +34,7 @@ export const getWorkoutByDate = async (date) => {
  */
 export const saveWorkout = async (entry) => {
   try {
-    const headers = await getAuthHeaders();
-    const res = await fetch(`${API}/api/workouts`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify(entry),
+    const res = await apiFetch(`workouts`, { auth: true, method: "POST", body: JSON.stringify(entry),
     });
     if (!res.ok) throw new Error("Failed to save workout");
     return await res.json();
@@ -54,11 +48,7 @@ export const saveWorkout = async (entry) => {
  */
 export const deleteWorkout = async (date) => {
   try {
-    const headers = await getAuthHeaders();
-    const res = await fetch(`${API}/api/workouts/${date}`, {
-      method: "DELETE",
-      headers,
-    });
+    const res = await apiFetch(`workouts/${date}`, { auth: true, method: "DELETE", });
     if (!res.ok) throw new Error("Failed to delete workout");
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- Add `client/src/lib/apiClient.js` with `apiFetch` (base URL + optional Firebase auth)
- Migrate pages/components from raw `fetch()` to the shared client

## Test plan
- [ ] Login and browse products/cart/checkout
- [ ] Admin dashboard and bug reports load with auth

Closes #274