### PR TITLE
refactor(cart): extract ensureOwnership middleware

### DIFF
--- a/server/middleware/ensureOwnership.js
+++ b/server/middleware/ensureOwnership.js
@@ -1,0 +1,21 @@
+/**
+ * Ensures the authenticated Firebase user matches the resource owner id.
+ * Must run after verifyFirebaseToken.
+ */
+const ensureOwnership = ({
+  source = "params",
+  field = "userId",
+  message = "Forbidden — you can only access your own resources",
+} = {}) => {
+  return (req, res, next) => {
+    const ownerId = source === "body" ? req.body?.[field] : req.params?.[field];
+
+    if (!ownerId || req.user?.uid !== ownerId) {
+      return res.status(403).json({ error: message });
+    }
+
+    return next();
+  };
+};
+
+module.exports = ensureOwnership;

--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -3,6 +3,11 @@ const router = express.Router();
 const Cart = require('../models/Cart');
 const Product = require('../models/Product');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
+const ensureOwnership = require('../middleware/ensureOwnership');
+
+const cartOwnership = ensureOwnership({
+  message: 'Forbidden — you can only access your own cart',
+});
 
 // Helper: adjust product reserved count
 async function adjustReserved(productId, delta) {
@@ -13,23 +18,12 @@ async function adjustReserved(productId, delta) {
   return prod;
 }
 
-// Helper: check that the token uid matches the userId in the route
-function checkOwnership(req, res) {
-  if (req.user.uid !== req.params.userId) {
-    res.status(403).json({ error: 'Forbidden — you can only access your own cart' });
-    return false;
-  }
-  return true;
-}
-
 /**
  * @route   GET /api/cart/:userId
  * @desc    Get or create a cart for the given user
  * @access  Private
  */
-router.get('/:userId', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.get('/:userId', verifyFirebaseToken, cartOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     let cart = await Cart.findOne({ userId });
@@ -47,8 +41,7 @@ router.get('/:userId', verifyFirebaseToken, async (req, res) => {
  * @desc    Add an item to the user's cart and reserve stock; body: { productId, quantity }
  * @access  Private
  */
-router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
+router.post('/:userId/add', verifyFirebaseToken, cartOwnership, async (req, res) => {
 
   try {
     const { userId } = req.params;
@@ -89,9 +82,7 @@ router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
  * @desc    Remove an item (or reduce its quantity) from the user's cart and release reserved stock; body: { productId, quantity }
  * @access  Private
  */
-router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.post('/:userId/remove', verifyFirebaseToken, cartOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
@@ -125,9 +116,7 @@ router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
  * @desc    Clear all items from the user's cart and release all reserved stock
  * @access  Private
  */
-router.delete('/:userId', verifyFirebaseToken, async (req, res) => {
-  if (!checkOwnership(req, res)) return;
-
+router.delete('/:userId', verifyFirebaseToken, cartOwnership, async (req, res) => {
   try {
     const { userId } = req.params;
     const cart = await Cart.findOne({ userId });

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -2,7 +2,13 @@ const express = require('express');
 const router = express.Router();
 const Order = require('../models/Order');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
+const ensureOwnership = require('../middleware/ensureOwnership');
 const { createOrder } = require('../services/orderService');
+
+const orderOwnership = ensureOwnership({
+  source: 'body',
+  message: 'Forbidden — you can only create orders for yourself',
+});
 
 /**
  * @route   POST /api/orders
@@ -11,15 +17,10 @@ const { createOrder } = require('../services/orderService');
  *          body: { userId, items?: [{ productId, quantity }] }
  * @access  Private
  */
-router.post('/', verifyFirebaseToken, async (req, res) => {
+router.post('/', verifyFirebaseToken, orderOwnership, async (req, res) => {
   const { userId, items } = req.body;
 
   if (!userId) return res.status(400).json({ error: 'userId required' });
-
-  // ownership check — token uid must match the userId in the body
-  if (req.user.uid !== userId) {
-    return res.status(403).json({ error: 'Forbidden — you can only create orders for yourself' });
-  }
 
   try {
     const order = await createOrder(userId, items);


### PR DESCRIPTION
## Summary
- Adds reusable `ensureOwnership` middleware
- Replaces inline `checkOwnership` in cart routes
- Uses the same middleware for order creation body `userId` checks

Closes #278

## Test plan
- [ ] Authenticated cart CRUD with matching `userId` succeeds
- [ ] Mismatched token vs route `userId` returns 403