### PR TITLE
fix: remove user message content logging in chat route (#347)

### DIFF
--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -56,7 +56,7 @@ router.post("/", async (req, res) => {
       return res.status(400).json({ error: "Message is required" });
     }
 
-    console.log("Processing message:", message.substring(0, 50));
+    console.log("Processing chat message:", { length: message.length, timestamp: Date.now() });
 
     const prompt = `${SYSTEM_PROMPT}\n\nUser: ${message}`;
 


### PR DESCRIPTION
## 📋 What does this PR do?
Fixes the privacy issue in server/routes/chat.js:59 where the first 50 characters of every user chat message were being logged to the server console. User messages could contain personal health info (fitness goals, body measurements, medical conditions). Changed it to log only anonymized metadata — message length and timestamp — instead of the actual message content.

## 🔗 Related Issue
Closes #347

## 🧪 How was this tested?
1. Sent a chat message via the chatbot
2. Checked server console — only `Processing chat message: { length: 42, timestamp: 1712345678901 }` logged
3. Verified the Gemini API still processes the full message correctly (the `message` variable is still passed to the API, only the log was changed)
4. Tested with both short and long messages to confirm length is reported accurately

## 📸 Screenshots (if UI changes)
No Ui changes has been made, so attaching a screenshot is not necessary

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue (#347)
- [x] I haven't introduced any new secrets or API keys