### PR TITLE
fix: add server-side email and phone format validation (#353)

### DIFF
--- a/server/routes/bugs.js
+++ b/server/routes/bugs.js
@@ -29,7 +29,11 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
 
     if (!title || !description)
       return res.status(400).json({ error: 'Title and description are required' });
-
+    
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (req.body.reporterEmail && !emailRegex.test(req.body.reporterEmail)) {
+      return res.status(400).json({ error: 'Invalid email format' });
+    }
     // Prefer authenticated name/email from token if present
     try {
       const authHeader = req.headers.authorization;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -200,6 +200,11 @@ router.put("/profile/:userId", async (req, res) => {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
+    const phoneRegex = /^\+?[\d\s\-]{7,15}$/;
+    if (req.body.phone && !phoneRegex.test(req.body.phone)) {
+      return res.status(400).json({ error: "Invalid phone number format" });
+    }
+
     const update = {};
     const allowed = ["name", "phone", "addresses", "defaultAddressId", "photoURL"];
     for (const k of allowed) {


### PR DESCRIPTION
## What does this PR do?
Adds server-side format validation for email and phone fields to prevent invalid data from being stored in the database.

## Related Issue
Closes #353

## How was this tested?
Tested locally using Invoke-RestMethod (PowerShell):
- `reporterEmail: "not-an-email"` → returns 400 `Invalid email format` ✅
- `reporterEmail: "test@gmail.com"` → saves successfully ✅
- `phone: "abc"` → returns 400 `Invalid phone number format` ✅
- `phone: "+91 9876543210"` → saves successfully ✅

## Screenshots
No UI changes.

## Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys