### PR TITLE
feat: add optional pagination to GET /api/products

### DIFF
--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -11,8 +11,28 @@ const verifyAdmin = require('../middleware/verifyAdmin');
  */
 router.get('/', async (req, res) => {
   try {
-    const products = await Product.find().sort({ productId: 1 });
-    res.json(products);
+    const page = parseInt(req.query.page);
+    const limit = parseInt(req.query.limit);
+
+    // If no pagination params provided, return all products (backward compatible)
+    if (!page || !limit) {
+      const products = await Product.find().sort({ productId: 1 });
+      return res.json(products);
+    }
+
+    // Pagination logic
+    const skip = (page - 1) * limit;
+    const [products, totalProducts] = await Promise.all([
+      Product.find().sort({ productId: 1 }).skip(skip).limit(limit),
+      Product.countDocuments(),
+    ]);
+
+    res.json({
+      data: products,
+      currentPage: page,
+      totalPages: Math.ceil(totalProducts / limit),
+      totalProducts,
+    });
   } catch (err) {
     res.status(500).json({ error: 'Server error' });
   }


### PR DESCRIPTION
## 📋 What does this PR do?
Adds optional pagination support to the `GET /api/products` endpoint. The API remains fully backward compatible — if no pagination params are provided, it returns all products as before.

## 🔗 Related Issue
Closes #292

## 🔧 Changes Made

### `server/routes/products.js`
- Added optional `?page` and `?limit` query parameter support
- Used Mongoose `.skip()` and `.limit()` for efficient pagination
- Used `Promise.all()` to run product query and count in parallel for performance
- Returns paginated response: `{ data, currentPage, totalPages, totalProducts }`
- **Backward compatible** — without `?page` and `?limit`, returns all products as before

## 🧪 How was this tested?
- `GET /api/products` → returns all 21 products ✅
- `GET /api/products?page=1&limit=5` → returns products 1-5, currentPage:1, totalPages:5 ✅
- `GET /api/products?page=2&limit=5` → returns products 6-10, currentPage:2, totalPages:5 ✅

## 📸 Screenshots (if UI changes)
No UI changes — backend only.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys