### PR TITLE
fix: validate product ID parameter to prevent NaN query injection

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
     "start": "node index.js",
     "dev": "nodemon index.js",
     "seed": "node seed.js",
-    "seed:fitness": "node seedFitnessCenters.js"
+    "seed:fitness": "node seedFitnessCenters.js",
+    "test": "jest --verbose"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -7,6 +7,19 @@ const validateRequest = require('../middleware/validateRequest');
 const { createProductSchema, updateProductSchema } = require('../validation/requestSchemas');
 
 /**
+ * Parse and validate the productId route parameter.
+ * Returns the numeric ID or sends a 400 response if invalid.
+ */
+function parseProductId(id, res) {
+  const parsed = Number(id);
+  if (isNaN(parsed) || !Number.isInteger(parsed) || parsed < 0) {
+    res.status(400).json({ error: 'Invalid product ID: must be a non-negative integer' });
+    return null;
+  }
+  return parsed;
+}
+
+/**
  * @route   GET /api/products
  * @desc    Returns all products sorted by productId in ascending order
  * @access  Public
@@ -47,7 +60,9 @@ router.get('/low-stock', async (req, res) => {
 // GET /api/products/:id - get product by productId
 router.get('/:id', async (req, res) => {
   try {
-    const product = await Product.findOne({ productId: Number(req.params.id) });
+    const productId = parseProductId(req.params.id, res);
+    if (productId === null) return;
+    const product = await Product.findOne({ productId });
     if (!product) return res.status(404).json({ error: 'Product not found' });
     res.json(product);
   } catch (err) {
@@ -80,7 +95,9 @@ router.post('/', verifyFirebaseToken, verifyAdmin, validateRequest(createProduct
  */
 router.put('/:id', verifyFirebaseToken, verifyAdmin, validateRequest(updateProductSchema), async (req, res) => {
   try {
-    const updated = await Product.findOneAndUpdate({ productId: Number(req.params.id) }, req.body, { new: true });
+    const productId = parseProductId(req.params.id, res);
+    if (productId === null) return;
+    const updated = await Product.findOneAndUpdate({ productId }, req.body, { new: true });
     if (!updated) return res.status(404).json({ error: 'Product not found' });
     res.json(updated);
   } catch (err) {
@@ -95,7 +112,9 @@ router.put('/:id', verifyFirebaseToken, verifyAdmin, validateRequest(updateProdu
  */
 router.delete('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   try {
-    const deleted = await Product.findOneAndDelete({ productId: Number(req.params.id) });
+    const productId = parseProductId(req.params.id, res);
+    if (productId === null) return;
+    const deleted = await Product.findOneAndDelete({ productId });
     if (!deleted) return res.status(404).json({ error: 'Product not found' });
     res.json({ success: true });
   } catch (err) {

--- a/server/tests/products.test.js
+++ b/server/tests/products.test.js
@@ -1,0 +1,113 @@
+const request = require('supertest');
+const express = require('express');
+const router = require('../routes/products');
+
+// Mock the Product model
+jest.mock('../models/Product', () => ({
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+  findOneAndDelete: jest.fn(),
+  find: jest.fn(),
+}));
+
+// Mock middleware
+jest.mock('../middleware/verifyFirebaseToken', () => (req, res, next) => next());
+jest.mock('../middleware/verifyAdmin', () => (req, res, next) => next());
+jest.mock('../middleware/validateRequest', () => () => (req, res, next) => next());
+
+const Product = require('../models/Product');
+
+const app = express();
+app.use(express.json());
+app.use('/api/products', router);
+
+describe('Product ID Validation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/products/:id', () => {
+    it('should return 400 for non-numeric ID', async () => {
+      const res = await request(app).get('/api/products/abc');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid product ID');
+    });
+
+    it('should return 400 for float ID', async () => {
+      const res = await request(app).get('/api/products/1.5');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid product ID');
+    });
+
+    it('should return 400 for negative ID', async () => {
+      const res = await request(app).get('/api/products/-1');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid product ID');
+    });
+
+    it('should return 400 for empty string ID', async () => {
+      const res = await request(app).get('/api/products/');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for valid ID with no matching product', async () => {
+      Product.findOne.mockResolvedValue(null);
+      const res = await request(app).get('/api/products/42');
+      expect(res.status).toBe(404);
+    });
+
+    it('should return product for valid numeric ID', async () => {
+      const mockProduct = { productId: 42, name: 'Test Product' };
+      Product.findOne.mockResolvedValue(mockProduct);
+      const res = await request(app).get('/api/products/42');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockProduct);
+    });
+  });
+
+  describe('PUT /api/products/:id', () => {
+    it('should return 400 for non-numeric ID', async () => {
+      const res = await request(app).put('/api/products/abc').send({ name: 'Updated' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid product ID');
+    });
+
+    it('should return 400 for NaN-producing input like "abc123"', async () => {
+      const res = await request(app).put('/api/products/abc123').send({ name: 'Updated' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for valid ID with no matching product', async () => {
+      Product.findOneAndUpdate.mockResolvedValue(null);
+      const res = await request(app).put('/api/products/42').send({ name: 'Updated' });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('DELETE /api/products/:id', () => {
+    it('should return 400 for non-numeric ID', async () => {
+      const res = await request(app).delete('/api/products/xyz');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('Invalid product ID');
+    });
+
+    it('should return 400 for path traversal attempt', async () => {
+      const res = await request(app).delete('/api/products/..%2F..%2Fetc');
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 404 for valid ID with no matching product', async () => {
+      Product.findOneAndDelete.mockResolvedValue(null);
+      const res = await request(app).delete('/api/products/99');
+      expect(res.status).toBe(404);
+    });
+
+    it('should return success for valid ID with existing product', async () => {
+      const mockProduct = { productId: 99, name: 'ToDelete' };
+      Product.findOneAndDelete.mockResolvedValue(mockProduct);
+      const res = await request(app).delete('/api/products/99');
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## What

Added input validation for the `productId` route parameter across GET, PUT, and DELETE `/api/products/:id` endpoints. Introduced a `parseProductId()` helper that ensures IDs are non-negative integers before executing database queries.

## Why

Issue #358 reported that `Number(req.params.id)` silently returns `NaN` for non-numeric inputs like `abc`, `1.5`, or path traversal attempts like `../etc`. This caused:

1. **Silent failures** - malformed IDs returned 404 instead of 400, making it impossible for API consumers to distinguish between "product not found" and "your request is malformed"
2. **Security risk** - unsanitized input was passed directly to Mongoose queries without validation

## How

- Created `parseProductId(id, res)` helper that validates:
  - Value is a valid number (not NaN)
  - Value is an integer (rejects floats like 1.5)
  - Value is non-negative (rejects -1)
- Replaced all three `Number(req.params.id)` calls with the helper
- Returns `400 Bad Request` with descriptive error for invalid IDs
- Returns `404 Not Found` only for valid IDs that don't match a product

## Testing

- [x] Added 13 unit tests in `server/tests/products.test.js`
- [x] Tests cover: non-numeric IDs, floats, negatives, empty strings, path traversal, and valid happy paths
- [x] Run `npm test` in the `server/` directory to verify
