### PR TITLE
fix: prevent negative stock via atomic $inc with precondition filter

### DIFF
--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -57,13 +57,23 @@ async function createOrder(userId, items = null) {
       const currentReserved = Number(p.reserved || 0);
       const newReserved = Math.max(0, currentReserved - it.quantity);
       
-      await Product.findOneAndUpdate(
-        { productId: p.productId },
+      const updated = await Product.findOneAndUpdate(
+        { productId: p.productId, stock: { $gte: it.quantity } },
         { 
           $inc: { stock: -it.quantity },
           $set: { reserved: newReserved }
-        }
+        },
+        { new: true }
       );
+
+      if (!updated) {
+        // Stock went below requested quantity between check and update (race condition).
+        // Roll back the order to avoid overselling.
+        await Order.findByIdAndDelete(order._id);
+        throw new Error(
+          `Insufficient stock for ${p.name} (concurrent order may have depleted it)`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

When deducting stock during order creation, the code uses MongoDB `\$inc` with no minimum constraint. In high-concurrency scenarios, a race condition between the stock availability check and the `\$inc` update allows multiple orders to pass the check before any decrement occurs, causing stock to go negative (overselling).

Fixes #351

## Solution

Added an atomic precondition filter to the `findOneAndUpdate` call:

```js
{ productId: p.productId, stock: { \$gte: it.quantity } }
```

This ensures the `$inc` update only succeeds when sufficient stock exists. If the update returns `null` (meaning another concurrent order depleted stock between the check and the update), the order is rolled back and an error is thrown.

### Changes in `server/services/orderService.js`:
- Added `stock: { \$gte: it.quantity }` filter to the `findOneAndUpdate` query
- Added `{ new: true }` option to return the updated document
- Added null-check on the result: if stock was insufficient due to a race condition, deletes the just-created order and throws a descriptive error

## Testing

This is a single atomic operation at the database level, eliminating the TOCTOU race condition. No concurrent order can bypass the check because the filter and update happen in one atomic MongoDB operation.