### PR TITLE
Add rate limiting for chat endpoint

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,7 +13,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.18.2",
-        "express-rate-limit": "^8.3.1",
+        "express-rate-limit": "^8.5.2",
         "firebase-admin": "^13.9.0",
         "helmet": "^8.1.0",
         "mongoose": "^7.0.0",
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
-      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.18.2",
-    "express-rate-limit": "^8.3.1",
+    "express-rate-limit": "^8.5.2",
     "firebase-admin": "^13.9.0",
     "helmet": "^8.1.0",
     "mongoose": "^7.0.0",

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -1,9 +1,20 @@
 // server/routes/chat.js
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 const { GoogleGenerativeAI, GoogleGenerativeAIFetchError } = require("@google/generative-ai");
 const Product = require("../models/Product");
 const router = express.Router();
 
+// Rate Limiter 
+const chatLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20,
+  message: {
+    error: "Too many requests, please try again later.",
+  },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 // Debug: Check if API key is loaded
 console.log("API Key exists:", !!process.env.GEMINI_API_KEY);
 console.log("API Key prefix:", process.env.GEMINI_API_KEY ? process.env.GEMINI_API_KEY.substring(0, 15) + "..." : "MISSING");
@@ -49,7 +60,7 @@ const getFallbackResponse = (message) => {
   }
 };
 
-router.post("/", async (req, res) => {
+router.post("/", chatLimiter,async (req, res) => {
   try {
     const { message } = req.body;
     if (!message?.trim()) {


### PR DESCRIPTION
## 📋 What does this PR do?
Added a separate rate limiter for the `/api/chat` endpoint to prevent excessive Gemini API usage and reduce the risk of unexpected API costs.

- Added endpoint-specific rate limiting using `express-rate-limit`
- Limited chat requests to 20 requests per 15 minutes
- Added proper 429 error response for excessive requests
- Improved security and protection against API abuse

## 🔗 Related Issue
Closes #346

## 🧪 How was this tested?
Describe how you tested your changes (manual steps, screenshots, etc.)
- Verified the server starts successfully after adding the rate limiter
- Confirmed the `/api/chat` route includes endpoint-specific rate limiting middleware
- Manually reviewed the implementation for correct 429 response handling
- Additional API testing was limited due to local environment/CORS setup issues

## 📸 Screenshots (if UI changes)
- No UI changes.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys