### PR TITLE
feat(security): add rate-limiting to github stats route

### DIFF
--- a/server/routes/github.js
+++ b/server/routes/github.js
@@ -1,5 +1,14 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit");
 const router = express.Router();
+
+const githubLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 30,
+  message: { error: "Too many GitHub stats requests, please try again later." },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 // Repository to proxy stats for
 const REPO = "parthbuilds-community/FitMart";
@@ -40,7 +49,7 @@ async function fetchPaginatedCount(url) {
   }
 }
 
-router.get("/stats", async (req, res) => {
+router.get("/stats", githubLimiter, async (req, res) => {
   // Serve from cache when fresh
   const now = Date.now();
   if (cache.stats && now - cache.ts < TTL_MS) {


### PR DESCRIPTION
## 📋 What does this PR do?
This PR adds \`express-rate-limit\` to the newly added \`/api/github/stats\` endpoint. While the route has an internal memory cache to protect against GitHub API rate limits, it lacked a rate limiter for the client itself. A malicious user could spam this endpoint causing high CPU/Memory usage. 
This sets a conservative limit of 30 requests per 15 minutes per IP specifically for this route.

## 🔗 Related Issue
Closes #379

## 🧪 How was this tested?
- Tested locally by spamming the endpoint and receiving a 429 Too Many Requests response after 30 hits.

## 📸 Screenshots (if UI changes)
N/A - This is a backend-only refactor.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys