### PR TITLE
enhancement(scripts): provide bash equivalents for PR scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -106,7 +106,9 @@ FitMart/
 ├── scripts/
 │   ├── README.md
 │   ├── merge-pr.ps1
-│   └── review-pr.ps1
+│   ├── merge-pr.sh
+│   ├── review-pr.ps1
+│   └── review-pr.sh
 ```
 
 These scripts are already included in the repository structure.
@@ -166,8 +168,8 @@ git mergepr 273
 ### Step 1 — Make Scripts Executable
 
 ```bash
-chmod +x scripts/review-pr.ps1
-chmod +x scripts/merge-pr.ps1
+chmod +x scripts/review-pr.sh
+chmod +x scripts/merge-pr.sh
 ```
 
 ---
@@ -175,14 +177,14 @@ chmod +x scripts/merge-pr.ps1
 ### Step 2 — Configure Git Aliases
 
 ```bash
-git config --global alias.reviewpr '!pwsh ./scripts/review-pr.ps1'
+git config --global alias.reviewpr '!./scripts/review-pr.sh'
 ```
 
 ```bash
-git config --global alias.mergepr '!pwsh ./scripts/merge-pr.ps1'
+git config --global alias.mergepr '!./scripts/merge-pr.sh'
 ```
 
-> Note: PowerShell Core (`pwsh`) must be installed on Linux/macOS.
+> Note: The merge script requires the GitHub CLI (`gh`) to be installed.
 
 ---
 
@@ -232,6 +234,8 @@ Copy the following files into that folder:
 
 * `review-pr.ps1`
 * `merge-pr.ps1`
+* `review-pr.sh`
+* `merge-pr.sh`
 
 ---
 
@@ -268,11 +272,11 @@ git config --global alias.mergepr "!powershell -ExecutionPolicy Bypass -File \"D
 ### Configure Git Aliases
 
 ```bash
-git config --global alias.reviewpr '!pwsh ~/git-tools/review-pr.ps1'
+git config --global alias.reviewpr '!~/git-tools/review-pr.sh'
 ```
 
 ```bash
-git config --global alias.mergepr '!pwsh ~/git-tools/merge-pr.ps1'
+git config --global alias.mergepr '!~/git-tools/merge-pr.sh'
 ```
 
 ---

--- a/scripts/merge-pr.sh
+++ b/scripts/merge-pr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: ./merge-pr.sh <pr-number>"
+    exit 1
+fi
+
+PR=$1
+
+# Get PR details from GitHub CLI
+PR_DATA=$(gh pr view $PR --json headRefName,headRepositoryOwner -t '{{.headRefName}} {{.headRepositoryOwner.login}}')
+
+if [ $? -ne 0 ]; then
+    echo "Error fetching PR details from GitHub CLI."
+    exit 1
+fi
+
+BRANCH=$(echo "$PR_DATA" | awk '{print $1}')
+USER=$(echo "$PR_DATA" | awk '{print $2}')
+
+echo -e "\nPreparing merge for PR #$PR..."
+
+git checkout main
+git pull origin main
+
+git merge --no-ff pr-$PR -m "Merge pull request #$PR from $USER/$BRANCH"
+
+git push origin main
+
+git branch -D pr-$PR
+
+echo -e "\nPR #$PR merged successfully."

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+    echo "Usage: ./review-pr.sh <pr-number>"
+    exit 1
+fi
+
+PR=$1
+
+echo -e "\nFetching PR #$PR..."
+
+git fetch origin pull/$PR/head:pr-$PR
+git checkout pr-$PR
+
+echo -e "\nChecked out PR #$PR successfully."


### PR DESCRIPTION
## 📋 What does this PR do?
This PR provides bash (\`.sh\`) equivalents for the existing \`.ps1\` maintainer scripts, ensuring that macOS and Linux contributors can natively use the \`git reviewpr\` and \`git mergepr\` aliases without needing to install PowerShell Core. 
It also updates the \`scripts/README.md\` to reflect the proper installation paths for Unix-based systems.

## 🔗 Related Issue
Closes #408 

## 🧪 How was this tested?
- Verified the \`.sh\` scripts execute correctly via \`bash\`.
- Verified the \`gh pr view\` command correctly parses JSON output without requiring third-party tools like \`jq\`.

## 📸 Screenshots (if UI changes)
N/A - This is a backend-only refactor.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys