### PR TITLE
feat(checkout): add skeleton loaders, inline address selector and robust error handling

### DIFF
--- a/client/src/components/AddressSelector.jsx
+++ b/client/src/components/AddressSelector.jsx
@@ -1,0 +1,69 @@
+import { useNavigate } from 'react-router-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function AddressSelector({ addresses = [], selectedAddressId, onSelect }) {
+  const navigate = useNavigate();
+
+  if (!addresses.length) {
+    return (
+      <div className="bg-stone-800 rounded-lg p-3">
+        <p className="text-xs text-stone-400 mb-2">No saved addresses</p>
+        <button
+          onClick={() => navigate('/profile')}
+          className="text-xs text-white underline hover:text-stone-300 transition-colors"
+          aria-label="Go to profile to add a shipping address"
+        >
+          Add a shipping address →
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-stone-400 tracking-wide uppercase mb-2">Ship to</p>
+
+      <AnimatePresence>
+        {addresses.map((addr) => {
+          const isSelected = addr.id === selectedAddressId;
+          return (
+            <motion.button
+              key={addr.id}
+              type="button"
+              onClick={() => onSelect(addr)}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2 }}
+              aria-pressed={isSelected}
+              aria-label={`Select address: ${addr.label}, ${addr.line1}, ${addr.city}`}
+              className={`w-full text-left rounded-lg p-3 border transition-all duration-200
+                ${isSelected
+                  ? 'bg-white text-stone-900 border-white'
+                  : 'bg-stone-800 text-stone-300 border-stone-700 hover:border-stone-500'
+                }`}
+            >
+              <div className={`text-xs font-medium mb-0.5 ${isSelected ? 'text-stone-900' : 'text-white'}`}>
+                {addr.label}
+                {isSelected && <span className="ml-2 text-stone-500">✓</span>}
+              </div>
+              <div className={`text-xs ${isSelected ? 'text-stone-600' : 'text-stone-400'}`}>
+                {addr.line1}{addr.line2 ? `, ${addr.line2}` : ''}
+              </div>
+              <div className={`text-xs ${isSelected ? 'text-stone-500' : 'text-stone-500'}`}>
+                {addr.city}{addr.state ? `, ${addr.state}` : ''} {addr.zip}
+              </div>
+            </motion.button>
+          );
+        })}
+      </AnimatePresence>
+
+      <button
+        onClick={() => navigate('/profile')}
+        className="text-xs text-stone-400 hover:text-stone-200 transition-colors underline mt-1"
+        aria-label="Manage addresses on profile page"
+      >
+        Manage addresses →
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/SkeletonItem.jsx
+++ b/client/src/components/SkeletonItem.jsx
@@ -1,0 +1,33 @@
+import { motion } from 'framer-motion';
+
+export default function SkeletonItem() {
+  return (
+    <motion.div
+      animate={{ opacity: [0.5, 1, 0.5] }}
+      transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+      className="bg-white border border-stone-200 rounded-2xl p-4 sm:p-6 flex gap-3 sm:gap-5"
+    >
+      {/* Image placeholder */}
+      <div className="w-16 h-16 sm:w-24 sm:h-24 bg-stone-100 rounded-xl shrink-0" />
+
+      <div className="flex-1 space-y-2">
+        {/* Brand */}
+        <div className="h-2.5 w-16 bg-stone-100 rounded-full" />
+        {/* Name */}
+        <div className="h-4 w-48 bg-stone-100 rounded-full" />
+        <div className="h-4 w-32 bg-stone-100 rounded-full" />
+        {/* Mobile price */}
+        <div className="mt-3 sm:hidden space-y-1">
+          <div className="h-2.5 w-12 bg-stone-100 rounded-full" />
+          <div className="h-5 w-20 bg-stone-100 rounded-full" />
+        </div>
+      </div>
+
+      {/* Desktop price */}
+      <div className="hidden sm:flex flex-col items-end gap-2 shrink-0">
+        <div className="h-2.5 w-10 bg-stone-100 rounded-full" />
+        <div className="h-6 w-20 bg-stone-100 rounded-full" />
+      </div>
+    </motion.div>
+  );
+}

--- a/client/src/components/SkeletonSummary.jsx
+++ b/client/src/components/SkeletonSummary.jsx
@@ -1,0 +1,41 @@
+import { motion } from 'framer-motion';
+
+export default function SkeletonSummary() {
+  return (
+    <motion.div
+      animate={{ opacity: [0.5, 1, 0.5] }}
+      transition={{ duration: 1.5, repeat: Infinity, ease: 'easeInOut' }}
+      className="bg-stone-900 rounded-2xl p-6 sm:p-8"
+    >
+      <div className="h-2.5 w-16 bg-stone-700 rounded-full mb-6" />
+
+      <div className="space-y-4 mb-6">
+        {/* Address block */}
+        <div className="bg-stone-800 rounded-lg p-3 space-y-2">
+          <div className="h-3 w-24 bg-stone-700 rounded-full" />
+          <div className="h-3 w-40 bg-stone-700 rounded-full" />
+          <div className="h-3 w-32 bg-stone-700 rounded-full" />
+        </div>
+
+        {/* Line items */}
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="flex justify-between">
+            <div className="h-3 w-28 bg-stone-700 rounded-full" />
+            <div className="h-3 w-14 bg-stone-700 rounded-full" />
+          </div>
+        ))}
+
+        <div className="h-px bg-stone-700 my-2" />
+
+        {/* Total */}
+        <div className="flex justify-between items-center">
+          <div className="h-3 w-10 bg-stone-700 rounded-full" />
+          <div className="h-7 w-24 bg-stone-700 rounded-full" />
+        </div>
+      </div>
+
+      {/* Button */}
+      <div className="h-12 w-full bg-stone-700 rounded-full" />
+    </motion.div>
+  );
+}

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -1,47 +1,61 @@
 // src/pages/Checkout.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import Navbar from "../components/Navbar";
+import SkeletonItem from "../components/SkeletonItem";
+import SkeletonSummary from "../components/SkeletonSummary";
+import AddressSelector from "../components/AddressSelector";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+const PLACEHOLDER_IMG = "https://placehold.co/96x96/f5f5f4/78716c?text=No+Image";
 
 export default function Checkout() {
   const navigate = useNavigate();
+  const abortRef = useRef(null);
 
-  const [items, setItems] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const [items, setItems]                   = useState([]);
+  const [loadingCart, setLoadingCart]       = useState(true);
+  const [loadingProfile, setLoadingProfile] = useState(true);
+  const [cartError, setCartError]           = useState(null);
+  const [profileError, setProfileError]     = useState(null);
   const [discountEligible, setDiscountEligible] = useState(false);
-  const [discountPercent, setDiscountPercent] = useState(10);
-  const [profile, setProfile] = useState(null);
+  const [discountPercent, setDiscountPercent]   = useState(10);
+  const [profile, setProfile]               = useState(null);
   const [selectedAddress, setSelectedAddress] = useState(null);
-  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuOpen, setMenuOpen]             = useState(false);
 
   useEffect(() => { document.title = "My Cart - FitMart"; }, []);
 
   useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const { signal } = controller;
+
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (!user) { navigate("/auth"); return; }
       const userId = user.uid;
 
+      // ── Fetch cart + products together ──────────────────────────────────
+      setLoadingCart(true);
+      setCartError(null);
+
       try {
         const headers = await getAuthHeaders();
 
-        const [cartRes, prodRes, discountRes, profileRes] = await Promise.all([
-          fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" }),
-          fetch(`${API}/api/products`),
-          fetch(`${API}/api/user/discount-status/${userId}`, { credentials: "include" }),
-          fetch(`${API}/api/user/profile/${userId}`, { headers, credentials: "include" }),
+        const [cartRes, prodRes, discountRes] = await Promise.all([
+          fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include", signal }),
+          fetch(`${API}/api/products`, { signal }),
+          fetch(`${API}/api/user/discount-status/${userId}`, { credentials: "include", signal }),
         ]);
 
         if (!cartRes.ok) throw new Error("Failed to fetch cart");
         if (!prodRes.ok) throw new Error("Failed to fetch products");
 
-        const cart = await cartRes.json();
+        const cart     = await cartRes.json();
         const products = await prodRes.json();
 
         if (discountRes.ok) {
@@ -50,34 +64,55 @@ export default function Checkout() {
           setDiscountPercent(d.discountPercent ?? 10);
         }
 
-        if (profileRes && profileRes.ok) {
-          const p = await profileRes.json();
-          setProfile(p);
-          const def = p?.defaultAddressId ? (p.addresses || []).find(a => a.id === p.defaultAddressId) : null;
-          setSelectedAddress(def || (p?.addresses && p.addresses[0]) || null);
+        if (cart.items?.length) {
+          const productMap = Object.fromEntries(products.map(p => [p.productId, p]));
+          const enriched   = cart.items
+            .map(item => ({ ...item, product: productMap[item.productId] }))
+            .filter(item => item.product);
+          setItems(enriched);
         }
-
-        if (!cart.items?.length) { setItems([]); setLoading(false); return; }
-
-        const productMap = Object.fromEntries(products.map(p => [p.productId, p]));
-        const enriched = cart.items
-          .map(item => ({ ...item, product: productMap[item.productId] }))
-          .filter(item => item.product);
-
-        setItems(enriched);
       } catch (err) {
-        setError(err.message);
+        if (err.name === 'AbortError') return;
+        setCartError(err.message);
       } finally {
-        setLoading(false);
+        setLoadingCart(false);
+      }
+
+      // ── Fetch profile independently so cart still renders if this fails ──
+      setLoadingProfile(true);
+      setProfileError(null);
+
+      try {
+        const headers   = await getAuthHeaders();
+        const profileRes = await fetch(`${API}/api/user/profile/${userId}`, {
+          headers, credentials: "include", signal,
+        });
+
+        if (!profileRes.ok) throw new Error("Failed to load profile");
+
+        const p = await profileRes.json();
+        setProfile(p);
+        const def = p?.defaultAddressId
+          ? (p.addresses || []).find(a => a.id === p.defaultAddressId)
+          : null;
+        setSelectedAddress(def || p?.addresses?.[0] || null);
+      } catch (err) {
+        if (err.name === 'AbortError') return;
+        setProfileError("Couldn't load your saved addresses. You can still view your order.");
+      } finally {
+        setLoadingProfile(false);
       }
     });
 
-    return () => unsubscribe();
+    return () => {
+      controller.abort();
+      unsubscribe();
+    };
   }, [navigate]);
 
-  const subtotal = items.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0);
+  const subtotal    = items.reduce((sum, { product, quantity }) => sum + product.price * quantity, 0);
   const discountAmt = discountEligible ? Math.round(subtotal * discountPercent / 100) : 0;
-  const total = subtotal - discountAmt;
+  const total       = subtotal - discountAmt;
 
   const handleProceed = () => {
     navigate("/payment", {
@@ -90,19 +125,15 @@ export default function Checkout() {
     });
   };
 
-  if (loading) return (
+  // Full-page cart error
+  if (!loadingCart && cartError) return (
     <PageShell menuOpen={menuOpen} setMenuOpen={setMenuOpen}>
-      <Spinner />
+      <ErrorMsg msg={cartError} />
     </PageShell>
   );
 
-  if (error) return (
-    <PageShell menuOpen={menuOpen} setMenuOpen={setMenuOpen}>
-      <ErrorMsg msg={error} />
-    </PageShell>
-  );
-
-  if (!items.length) return (
+  // Empty cart (only after loading done)
+  if (!loadingCart && !cartError && !items.length) return (
     <PageShell menuOpen={menuOpen} setMenuOpen={setMenuOpen}>
       <EmptyCart navigate={navigate} />
     </PageShell>
@@ -123,6 +154,7 @@ export default function Checkout() {
             className="flex items-center gap-2 border border-stone-200 hover:border-stone-300
                        bg-white text-stone-700 hover:text-stone-900 text-sm px-4 sm:px-5 py-2.5
                        rounded-full transition-all duration-300 hover:shadow-md group cursor-pointer mb-5 sm:mb-6"
+            aria-label="Back to shop"
           >
             <span className="transition-transform duration-200 group-hover:-translate-x-1">←</span>
             Back to Shop
@@ -137,144 +169,172 @@ export default function Checkout() {
           </h1>
         </div>
 
-        {/* On mobile: summary appears ABOVE product list for quick visibility */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
 
-          {/* ── Order summary — top on mobile, sidebar on lg ── */}
+          {/* ── Order summary ── */}
           <div className="lg:col-span-1 order-first lg:order-last">
-            <div className="bg-stone-900 rounded-2xl p-6 sm:p-8 lg:sticky lg:top-24">
-              <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5 sm:mb-6">Summary</p>
-              <div className="space-y-3 mb-5 sm:mb-6">
-                {selectedAddress && (
-                  <div className="bg-stone-800 text-white rounded-lg p-3">
-                    <div className="text-sm font-medium">Shipping to</div>
-                    <div className="text-sm">{selectedAddress.label} — {selectedAddress.line1}{selectedAddress.line2 ? `, ${selectedAddress.line2}` : ''}</div>
-                    <div className="text-sm text-stone-200">{selectedAddress.city}{selectedAddress.state ? `, ${selectedAddress.state}` : ''} {selectedAddress.zip}</div>
-                    <div className="text-xs mt-2"><button onClick={() => navigate('/profile')} className="underline">Edit addresses</button></div>
+            {loadingProfile && !profile ? (
+              <SkeletonSummary />
+            ) : (
+              <div className="bg-stone-900 rounded-2xl p-6 sm:p-8 lg:sticky lg:top-24">
+                <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5 sm:mb-6">Summary</p>
+
+                {/* Profile error inline */}
+                {profileError && (
+                  <div className="bg-stone-800 border border-stone-700 rounded-lg p-3 mb-4">
+                    <p className="text-xs text-stone-400">{profileError}</p>
                   </div>
                 )}
 
-                <div className="flex justify-between text-sm text-stone-300">
-                  <span>Subtotal ({items.length} item{items.length > 1 ? "s" : ""})</span>
-                  <span>{fmt(subtotal)}</span>
-                </div>
-                {discountEligible && (
-                  <div className="flex justify-between text-sm">
-                    <span className="text-stone-400">Welcome {discountPercent}% off</span>
-                    <span className="text-stone-300">−{fmt(discountAmt)}</span>
+                {/* Address selector */}
+                {!profileError && (
+                  <div className="mb-5">
+                    <AddressSelector
+                      addresses={profile?.addresses || []}
+                      selectedAddressId={selectedAddress?.id}
+                      onSelect={setSelectedAddress}
+                    />
                   </div>
                 )}
-                <div className="flex justify-between text-sm text-stone-300">
-                  <span>Shipping</span>
-                  <span className="text-stone-400">Free</span>
+
+                <div className="space-y-3 mb-5 sm:mb-6">
+                  <div className="flex justify-between text-sm text-stone-300">
+                    <span>Subtotal ({items.length} item{items.length > 1 ? "s" : ""})</span>
+                    <span>{fmt(subtotal)}</span>
+                  </div>
+                  {discountEligible && (
+                    <div className="flex justify-between text-sm">
+                      <span className="text-stone-400">Welcome {discountPercent}% off</span>
+                      <span className="text-stone-300">−{fmt(discountAmt)}</span>
+                    </div>
+                  )}
+                  <div className="flex justify-between text-sm text-stone-300">
+                    <span>Shipping</span>
+                    <span className="text-stone-400">Free</span>
+                  </div>
+                  <div className="h-px bg-stone-700 my-2" />
+                  <div className="flex justify-between items-center">
+                    <span className="text-sm text-white font-medium">Total</span>
+                    <span
+                      style={{ fontFamily: "'DM Serif Display', serif" }}
+                      className="text-2xl sm:text-3xl text-white"
+                    >
+                      {fmt(total)}
+                    </span>
+                  </div>
                 </div>
-                <div className="h-px bg-stone-700 my-2" />
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-white font-medium">Total</span>
-                  <span
-                    style={{ fontFamily: "'DM Serif Display', serif" }}
-                    className="text-2xl sm:text-3xl text-white"
-                  >
-                    {fmt(total)}
-                  </span>
-                </div>
+
+                {/* No address warning */}
+                {!selectedAddress && !profileError && (
+                  <p className="text-xs text-red-400 mb-3" role="alert">
+                    Select a shipping address to continue.
+                  </p>
+                )}
+
+                <button
+                  onClick={handleProceed}
+                  disabled={!selectedAddress}
+                  aria-disabled={!selectedAddress}
+                  aria-label={selectedAddress ? "Proceed to payment" : "Select a shipping address to proceed"}
+                  className={`w-full text-sm px-8 py-3.5 rounded-full transition-colors
+                             font-medium min-h-12 focus:outline-none focus:ring-2
+                             focus:ring-white focus:ring-offset-2 focus:ring-offset-stone-900
+                             ${selectedAddress
+                               ? 'bg-white text-stone-900 hover:bg-stone-100 cursor-pointer'
+                               : 'bg-stone-700 text-stone-500 cursor-not-allowed'
+                             }`}
+                >
+                  Proceed to Payment →
+                </button>
+                <p className="text-xs text-stone-500 text-center mt-4">Secured by Razorpay</p>
               </div>
-
-              {/* Persistent error message when no address is selected */}
-              {!selectedAddress && (
-                <p className="text-xs text-red-500 mt-2 mb-2">
-                  Please <button onClick={() => navigate('/profile')} className="underline cursor-pointer">Add a Shipping Address</button> to continue.
-                </p>
-              )}
-
-              <button
-                onClick={handleProceed}
-                disabled={!selectedAddress}
-                className={`w-full text-sm px-8 py-3.5 rounded-full
-                           transition-colors font-medium min-h-12 ${selectedAddress
-                    ? 'bg-white text-stone-900 hover:bg-stone-100'
-                    : 'bg-stone-200 text-stone-400 cursor-not-allowed'
-                  }`}
-              >
-                Proceed to Payment →
-              </button>
-              <p className="text-xs text-stone-500 text-center mt-4">Secured by Razorpay</p>
-            </div>
+            )}
           </div>
 
           {/* ── Product list ── */}
           <div className="lg:col-span-2 space-y-3 sm:space-y-4 order-last lg:order-first">
-            {items.map(({ product, quantity }) => (
-              <div
-                key={product.productId}
-                className="bg-white border border-stone-200 rounded-2xl p-4 sm:p-6
-                           flex gap-3 sm:gap-5 hover:border-stone-300 hover:shadow-lg
-                           transition-all duration-300"
-              >
-                {/* Product image — smaller on mobile */}
-                <img
-                  src={product.image} alt={product.name}
-                  className="w-16 h-16 sm:w-24 sm:h-24 object-cover rounded-xl shrink-0 bg-stone-100"
-                />
-                <div className="flex-1 min-w-0">
-                  <p className="text-[10px] tracking-[0.15em] uppercase text-stone-400 mb-1">
-                    {product.brand}
-                  </p>
-                  <h3
-                    style={{ fontFamily: "'DM Serif Display', serif" }}
-                    className="text-base sm:text-xl text-stone-900 leading-tight mb-1 sm:mb-2
-                               line-clamp-2 sm:truncate"
+            {loadingCart ? (
+              <>
+                <SkeletonItem />
+                <SkeletonItem />
+                <SkeletonItem />
+              </>
+            ) : (
+              <>
+                {items.map(({ product, quantity }) => (
+                  <div
+                    key={product.productId}
+                    className="bg-white border border-stone-200 rounded-2xl p-4 sm:p-6
+                               flex gap-3 sm:gap-5 hover:border-stone-300 hover:shadow-lg
+                               transition-all duration-300"
                   >
-                    {product.name}
-                  </h3>
-                  {product.badge && (
-                    <span className="text-[10px] tracking-widest uppercase bg-stone-900
-                                     text-white px-2.5 py-1 rounded-full">
-                      {product.badge}
-                    </span>
-                  )}
-                  {/* Price visible on mobile inline */}
-                  <div className="mt-2 sm:hidden">
-                    <p className="text-xs text-stone-400">Qty {quantity}</p>
-                    <p
-                      style={{ fontFamily: "'DM Serif Display', serif" }}
-                      className="text-lg text-stone-900"
-                    >
-                      {fmt(product.price * quantity)}
-                    </p>
+                    <img
+                      src={product.image}
+                      alt={product.name ? `${product.name} product image` : 'Product image'}
+                      onError={e => { e.currentTarget.src = PLACEHOLDER_IMG; }}
+                      className="w-16 h-16 sm:w-24 sm:h-24 object-cover rounded-xl shrink-0 bg-stone-100"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-[10px] tracking-[0.15em] uppercase text-stone-400 mb-1">
+                        {product.brand}
+                      </p>
+                      <h3
+                        style={{ fontFamily: "'DM Serif Display', serif" }}
+                        className="text-base sm:text-xl text-stone-900 leading-tight mb-1 sm:mb-2
+                                   line-clamp-2 sm:truncate"
+                      >
+                        {product.name}
+                      </h3>
+                      {product.badge && (
+                        <span className="text-[10px] tracking-widest uppercase bg-stone-900
+                                         text-white px-2.5 py-1 rounded-full">
+                          {product.badge}
+                        </span>
+                      )}
+                      {/* Mobile price */}
+                      <div className="mt-2 sm:hidden">
+                        <p className="text-xs text-stone-400">Qty {quantity}</p>
+                        <p
+                          style={{ fontFamily: "'DM Serif Display', serif" }}
+                          className="text-lg text-stone-900"
+                        >
+                          {fmt(product.price * quantity)}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Desktop price */}
+                    <div className="text-right shrink-0 hidden sm:block">
+                      <p className="text-xs text-stone-400 mb-1">Qty {quantity}</p>
+                      <p
+                        style={{ fontFamily: "'DM Serif Display', serif" }}
+                        className="text-2xl text-stone-900"
+                      >
+                        {fmt(product.price * quantity)}
+                      </p>
+                      {product.originalPrice > product.price && (
+                        <p className="text-xs text-stone-400 line-through">
+                          {fmt(product.originalPrice * quantity)}
+                        </p>
+                      )}
+                    </div>
                   </div>
-                </div>
+                ))}
 
-                {/* Desktop-only right-aligned price */}
-                <div className="text-right shrink-0 hidden sm:block">
-                  <p className="text-xs text-stone-400 mb-1">Qty {quantity}</p>
-                  <p
-                    style={{ fontFamily: "'DM Serif Display', serif" }}
-                    className="text-2xl text-stone-900"
-                  >
-                    {fmt(product.price * quantity)}
-                  </p>
-                  {product.originalPrice > product.price && (
-                    <p className="text-xs text-stone-400 line-through">
-                      {fmt(product.originalPrice * quantity)}
-                    </p>
-                  )}
-                </div>
-              </div>
-            ))}
-
-            {/* Welcome discount callout */}
-            {discountEligible && (
-              <div className="bg-stone-100 border border-stone-200 rounded-2xl px-4 sm:px-6 py-4
-                              flex items-center gap-3 sm:gap-4">
-                <span className="text-stone-900 text-lg shrink-0">✓</span>
-                <div>
-                  <p className="text-sm font-medium text-stone-900">Welcome discount applied</p>
-                  <p className="text-xs text-stone-500 mt-0.5">
-                    {discountPercent}% off your first order — saving you {fmt(discountAmt)}
-                  </p>
-                </div>
-              </div>
+                {/* Welcome discount callout */}
+                {discountEligible && (
+                  <div className="bg-stone-100 border border-stone-200 rounded-2xl px-4 sm:px-6 py-4
+                                  flex items-center gap-3 sm:gap-4">
+                    <span className="text-stone-900 text-lg shrink-0" aria-hidden="true">✓</span>
+                    <div>
+                      <p className="text-sm font-medium text-stone-900">Welcome discount applied</p>
+                      <p className="text-xs text-stone-500 mt-0.5">
+                        {discountPercent}% off your first order — saving you {fmt(discountAmt)}
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </>
             )}
           </div>
 
@@ -293,19 +353,11 @@ function PageShell({ children, menuOpen, setMenuOpen }) {
   );
 }
 
-function Spinner() {
-  return (
-    <div className="flex items-center justify-center h-64">
-      <div className="w-8 h-8 border-2 border-stone-900 border-t-transparent rounded-full animate-spin" />
-    </div>
-  );
-}
-
 function ErrorMsg({ msg }) {
   return (
     <div className="max-w-md mx-auto mt-16 sm:mt-24 bg-red-50 border border-red-100
-                    rounded-2xl p-6 sm:p-8 text-center sm:mx-auto">
-      <p className="text-red-600 text-sm">{msg}</p>
+                    rounded-2xl p-6 sm:p-8 text-center">
+      <p className="text-red-600 text-sm" role="alert">{msg}</p>
     </div>
   );
 }
@@ -313,12 +365,13 @@ function ErrorMsg({ msg }) {
 function EmptyCart({ navigate }) {
   return (
     <div className="flex flex-col items-center justify-center h-64 text-center gap-4 px-4">
-      <p className="text-4xl text-stone-300">∅</p>
+      <p className="text-4xl text-stone-300" aria-hidden="true">∅</p>
       <p className="text-stone-500 text-sm">Your cart is empty</p>
       <button
         onClick={() => navigate("/home")}
         className="bg-stone-900 text-white text-sm px-8 py-3 rounded-full
                    hover:bg-stone-700 transition-colors min-h-11"
+        aria-label="Continue shopping"
       >
         Continue Shopping
       </button>


### PR DESCRIPTION
## 📋 What does this PR do?
Improves the Checkout page UX with progressive rendering, inline address selection, per-section error handling, and accessibility improvements.

**New components:**
- `SkeletonItem.jsx` — animated skeleton for each product row
- `SkeletonSummary.jsx` — animated skeleton for the summary panel
- `AddressSelector.jsx` — inline address picker inside summary, no need to leave the page

**Checkout.jsx changes:**
- Replaced single spinner with skeleton loaders for product list and summary independently
- Split into per-section loading flags — cart and profile load separately
- Added AbortController — cancels all fetches on component unmount, no stale state
- Per-section error handling — profile failure shows inline warning, products still render
- Image fallback — broken product images show placeholder instead of broken icon
- Alt text improved — `${product.name} product image` for screen readers
- Added `aria-disabled`, `aria-label`, `aria-pressed`, `role="alert"` throughout
- Proceed button has proper focus ring for keyboard navigation

## 🔗 Related Issue
Closes #392

## 🧪 How was this tested?
- Slow 3G throttling — skeleton loaders appear before real content
- Products and summary load independently and progressively
- Address selector shows saved addresses inline, selectable without leaving page
- Proceed button disabled until address selected
- Broken image URLs fallback to placeholder
- Navigating away mid-load cancels fetches cleanly

## 📸 Screenshots (if UI changes)
<img width="441" height="329" alt="image" src="https://github.com/user-attachments/assets/cd593839-ced8-48cf-87e0-cd1b021a94a2" />
<img width="916" height="693" alt="image" src="https://github.com/user-attachments/assets/7a5378a1-6f88-45fb-8243-3bec86c20fe3" />


## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
- [x] New components documented in PR description
