### PR TITLE
feat(chat): add rolling conversation history and clear chat button

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -63,6 +63,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -950,6 +951,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.8.tgz",
       "integrity": "sha512-WiE9uCGRLUnShdjb9iP20sA3ToWrBbNXr14/N5mow7Nls9dmKgfGaGX5cynLvrltxq2OrDLh1VDNaUgsnS/k/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1016,6 +1018,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.8.tgz",
       "integrity": "sha512-4De6SUZ36zozl9kh5rZSxKWULpgty27rMzZ6x+xkoo7+NWyhWyFdsdvhFsWhTw/9GGj0wXIcbTjwHYCUIUuHyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.8",
         "@firebase/component": "0.7.0",
@@ -1031,7 +1034,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.12.0",
@@ -1482,6 +1486,7 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2499,6 +2504,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2546,6 +2552,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2659,6 +2666,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3077,6 +3085,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4188,6 +4197,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4228,7 +4238,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -4283,6 +4292,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4292,6 +4302,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4311,6 +4322,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -4411,7 +4423,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4760,6 +4773,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -4963,6 +4977,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -8,7 +8,9 @@ const WELCOME = {
   text: "Hello! I'm your FitMart fitness assistant. Ask me anything about workouts, diet, protein, weight loss, or muscle gain.",
 };
 
-
+// Maximum number of history entries (messages) to send to the server.
+// Matches the server-side MAX_HISTORY_TURNS cap.
+const MAX_HISTORY = 6;
 
 const QUICK_REPLIES = [
   {
@@ -27,7 +29,7 @@ const QUICK_REPLIES = [
     label: "⚖️ Lose weight",
     prompt: "How do I lose weight sustainably?",
   },
-]
+];
 
 export default function FitnessChatBot() {
   const [open, setOpen] = useState(false);
@@ -37,6 +39,7 @@ export default function FitnessChatBot() {
   const [visible, setVisible] = useState(false);
   const bottomRef = useRef(null);
   const inputRef = useRef(null);
+  const historyRef = useRef([]);
 
   useEffect(() => {
     const t = setTimeout(() => setVisible(true), 120);
@@ -61,10 +64,17 @@ export default function FitnessChatBot() {
     return () => { document.body.style.overflow = ""; };
   }, [open]);
 
+  /** Resets the chat to its initial state and wipes conversation history. */
+  const clearChat = () => {
+    setMsgs([WELCOME]);
+    setInput("");
+    historyRef.current = [];
+  };
+
   const send = async (customText = input) => {
     // customText is passed from quick replies,
-    // otherwise fallback to manual textarea input
-    // Prevent crashes if non-string values are passed into send()
+    // otherwise fallback to manual textarea input.
+    // Prevent crashes if non-string values are passed into send
     const text =
       typeof customText === "string"
         ? customText.trim()
@@ -74,15 +84,28 @@ export default function FitnessChatBot() {
     setMsgs((prev) => [...prev, { role: "user", text }]);
     setInput("");
     setTyping(true);
+
+    // Snapshot and cap history before the fetch so the ref can't mutate mid-flight.
+    const historySnapshot = historyRef.current.slice(-MAX_HISTORY);
+
     try {
       const res = await fetch(`${API}/api/chat`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: text }),
+        body: JSON.stringify({ message: text, history: historySnapshot }),
       });
       if (!res.ok) throw new Error("Request failed");
       const data = await res.json();
-      setMsgs((prev) => [...prev, { role: "bot", text: data.reply }]);
+      const botText = data.reply;
+
+      setMsgs((prev) => [...prev, { role: "bot", text: botText }]);
+
+      // Append both turns to history after a successful round-trip.
+      historyRef.current = [
+        ...historyRef.current,
+        { role: "user", parts: [{ text }] },
+        { role: "assistant", parts: [{ text: botText }] },
+      ];
     } catch {
       setMsgs((prev) => [
         ...prev,
@@ -195,6 +218,10 @@ export default function FitnessChatBot() {
         .fm-scrollbar::-webkit-scrollbar { width: 4px; }
         .fm-scrollbar::-webkit-scrollbar-track { background: transparent; }
         .fm-scrollbar::-webkit-scrollbar-thumb { background: #e7e5e3; border-radius: 99px; }
+        .fm-clear-btn {
+          transition: color 0.15s ease, background 0.15s ease;
+        }
+        .fm-clear-btn:hover { color: #ef4444; background: rgba(239,68,68,0.1); }
       `}</style>
 
       {/* ── Chat Window ── */}
@@ -228,11 +255,30 @@ export default function FitnessChatBot() {
               Fitness Assistant
             </h3>
           </div>
-          <div className="flex items-center gap-2 sm:gap-3">
-            <span className="flex items-center gap-1.5 text-[10px] text-stone-400">
+          <div className="flex items-center gap-1 sm:gap-2">
+            <span className="flex items-center gap-1.5 text-[10px] text-stone-400 mr-1">
               <span className="w-1.5 h-1.5 rounded-full bg-stone-400 animate-pulse" />
               Online
             </span>
+            {msgs.length > 1 && (
+              <button
+                onClick={clearChat}
+                className="fm-clear-btn text-stone-400 text-[10px] tracking-wide uppercase
+                           min-w-8 min-h-8 flex items-center justify-center
+                           rounded-full px-2 gap-1"
+                aria-label="Clear chat history"
+                title="Clear conversation"
+              >
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                  stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M3 6h18" />
+                  <path d="M8 6V4h8v2" />
+                  <path d="M19 6l-1 14H6L5 6" />
+                </svg>
+                <span className="hidden sm:inline">Clear</span>
+              </button>
+            )}
+
             <button
               onClick={() => setOpen(false)}
               className="text-stone-400 hover:text-white transition-colors text-2xl
@@ -274,8 +320,6 @@ export default function FitnessChatBot() {
             </div>
           ))}
 
-
-
           {/* Typing Indicator */}
           {typing && (
             <div className="fm-msg flex justify-start">
@@ -297,8 +341,8 @@ export default function FitnessChatBot() {
 
         <div className="h-px bg-stone-100 shrink-0" />
 
-        {/*  Show quick replies only before the conversation starts
-         to keep the chat area clean after interaction begins */}
+        {/* Show quick replies only before the conversation starts
+            to keep the chat area clean after interaction begins */}
         {msgs.length === 1 && (
           <div className="flex gap-2 overflow-x-auto whitespace-nowrap pb-1 scrollbar-hide">
             {QUICK_REPLIES.map((reply) => (

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1271,6 +1271,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -29,16 +29,73 @@ const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 const modelName = process.env.GEMINI_MODEL_NAME || "gemini-2.5-flash";
 const model = genAI.getGenerativeModel({ model: modelName });
 
+const MAX_HISTORY_TURNS = 6;
+
+/**
+ * Validates that the history value from the request body is a usable array.
+ * Returns an empty array for any invalid / missing input (backward compatible).
+ *
+ * @param {*} raw - raw value from req.body.history
+ * @returns {Array<{role: string, parts: [{text: string}]}>}
+ */
+
+function sanitiseHistory(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.filter(
+    (entry) =>
+      entry &&
+      typeof entry.role === "string" &&
+      Array.isArray(entry.parts) &&
+      entry.parts.length > 0 &&
+      typeof entry.parts[0]?.text === "string"
+  );
+}
+
+/**
+ * Converts a validated history array into a plain-text conversation block
+ * prepended to the system prompt so Gemini has prior turn context.
+ *
+ * @param {Array<{role: string, parts: [{text: string}]}>} history
+ * @returns {string}
+ */
+
+function buildHistoryBlock(history) {
+  if (!history || history.length === 0) return "";
+
+  const capped = history.slice(-MAX_HISTORY_TURNS);
+  if (capped.length < history.length) {
+    console.warn(`⚠️ Chat history truncated from ${history.length} to ${MAX_HISTORY_TURNS} turns`);
+  }
+
+  const lines = capped.map((entry) => {
+    const role = entry.role === "assistant" ? "Assistant" : "User";
+    const text = entry?.parts?.[0]?.text ?? "";
+    return `${role}: ${text}`;
+  });
+
+  return lines.join("\n");
+}
+
 router.post("/", chatLimiter, async (req, res) => {
   try {
-    const { message } = req.body;
+    const { message, history: rawHistory } = req.body;
     if (!message?.trim()) {
       return res.status(400).json({ error: "Message is required" });
     }
 
-    console.log("Processing chat message:", { length: message.length, timestamp: Date.now() });
+    const history = sanitiseHistory(rawHistory);
 
-    const prompt = `${SYSTEM_PROMPT}\n\nUser: ${message}`;
+    console.log("Processing chat message:", {
+      length: message.length,
+      historyTurns: history.length,
+      timestamp: Date.now(),
+    });
+
+    // Build the full prompt: system instructions + prior conversation turns + current message.
+    const historyBlock = buildHistoryBlock(history);
+    const prompt = historyBlock
+      ? `${SYSTEM_PROMPT}\n\nConversation so far:\n${historyBlock}\n\nUser: ${message}`
+      : `${SYSTEM_PROMPT}\n\nUser: ${message}`;
 
     let reply;
     let usedFallback = false;


### PR DESCRIPTION
## 📋 What does this PR do?
Adds rolling conversation history to the FitMart AI chatbot so it 
remembers context across messages in the same session. Also adds a 
"Clear chat" button to reset the conversation.

## 🔗 Related Issue
Closes #396

## 🧪 How was this tested?

**Test 1 — Context retention**
Sent "I'm vegetarian and want to gain muscle" then followed up with 
"What about supplements?" — bot responded with vegetarian-specific 
supplement recommendations using prior context. (video attached)
https://github.com/user-attachments/assets/026b6fa0-2e42-492f-81d0-cec215c331cc

**Test 2 — Clear chat**
Had a multi-turn conversation, clicked Clear, verified welcome message 
reset, then asked a follow-up — bot had no memory of previous session. 
(video attached)
https://github.com/user-attachments/assets/bae3148e-34fc-41a2-b87d-a9aacfaa5086

**Test 3 — History cap at 6 turns**
Server logs confirmed history never exceeds 6 turns:
historyTurns: 0 → 2 → 4 → 6 → 6 (screenshot attached)
<img width="631" height="500" alt="image" src="https://github.com/user-attachments/assets/2e5d176d-e0fb-4597-b73f-b0cfa81b6c23" />

**Test 4 — Backward compatibility**
Verified via `sanitiseHistory()` returning `[]` for missing/malformed 
input — no breaking changes to existing functionality.


## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys