### PR TITLE
fix: increase body parser limit from 10kb to 10mb

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -97,8 +97,8 @@ app.use(
 );
 
 app.use(helmet());
-app.use(express.json({ limit: "10kb" }));
-app.use(express.urlencoded({ extended: true, limit: "10kb" }));
+app.use(express.json({ limit: "10mb" }));
+app.use(express.urlencoded({ extended: true, limit: "10mb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
 app.disable("etag");
 


### PR DESCRIPTION
Closes #360

## What does this PR do?
- Increased Express body parser limit from 10KB to 10MB
- Updated both express.json() and express.urlencoded() middleware
- Server now handles larger file uploads and bulk data requests

## Files Changed
- server/index.js (lines 100-101)