### PR TITLE
refactor: wrap FitnessChatBot in ErrorBoundary to prevent UI crashes

### DIFF
--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -16,12 +16,11 @@ class ErrorBoundary extends React.Component {
   }
 
   render() {
-    if (this.state.hasError) {
-      return <ErrorFallback />;
-    }
-
-    return this.props.children;
+  if (this.state.hasError) {
+    return this.props.fallback ?? <ErrorFallback />;
   }
+  return this.props.children;
+}
 }
 
 function ErrorFallback() {

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -8,6 +8,7 @@ import CartDrawer from "../components/CartDrawer";
 import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessChatBot from "../components/FitnessChatBot";
+import ErrorBoundary from "../components/ErrorBoundary";
 import WelcomeBanner from "../components/WelcomeBanner";
 import { useWelcomeDiscount } from "../auth/useWelcomeDiscount";
 import BMICalculator from "../components/BMICalculator";
@@ -665,7 +666,14 @@ export default function HomePage() {
         cart={cart} cartCount={cartCount} cartTotal={cartTotal}
         updateQty={updateQty} removeFromCart={removeFromCart}
       />
-      <FitnessChatBot />
+      <ErrorBoundary fallback={
+        <div className="fixed bottom-6 right-6 z-50 bg-white border border-stone-200 rounded-2xl p-4 shadow-lg max-w-xs">
+          <p className="text-xs tracking-[0.15em] uppercase text-stone-400 mb-1">Assistant</p>
+          <p className="text-sm text-stone-600">Chat is currently unavailable. Please refresh the page.</p>
+        </div>
+      }>
+        <FitnessChatBot />
+      </ErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## 📋 What does this PR do?

Wraps the `<FitnessChatBot />` component in a targeted `ErrorBoundary` 
inside `HomePage.jsx` to prevent the entire page from crashing if the 
chatbot encounters a malformed API response or markdown parsing error.

Also adds optional `fallback` prop support to `ErrorBoundary` so a 
contextually appropriate fallback UI can be shown instead of the 
full-page error screen.

## 🔗 Related Issue
Closes #438

## 🛠️ Changes Made
- `client/src/components/ErrorBoundary.jsx` — added optional `fallback` 
prop support using nullish coalescing (`??`)
- `client/src/pages/HomePage.jsx` — imported `ErrorBoundary` and wrapped 
`<FitnessChatBot />` with a chatbot-specific fallback UI

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys