### PR TITLE
fix: resolve hardcoded low-stock threshold in dashboard route (fixes …

### DIFF
--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -7,6 +7,8 @@ const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
+const { LOW_STOCK_THRESHOLD } = require('../config/constants');
+
 
 // ── Helper: get the start date based on the time range filter
 // 'today'  -> start of today
@@ -50,7 +52,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });


### PR DESCRIPTION
…#242)

- Imported LOW_STOCK_THRESHOLD from central constants config
- Removed hardcoded threshold value of 10 in dashboard.js
- Centralized threshold value to 5 across all server routes

📋 What does this PR do?
This PR centralizes the `LOW_STOCK_THRESHOLD` inside the server dashboard route by importing it from the central constants config instead of using a hardcoded value of 10.

🔗 Related Issue
Closes #242

🧪 How was this tested?
Verified that the server-side files import and compile correctly with the centralized threshold value of 5.

📸 Screenshots (if UI changes)
N/A (Backend logic refactor)

✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
