### PR TITLE
docs: move Redis config from Prerequisites to Environment Variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,11 @@ RAZORPAY_KEY_SECRET=<your_razorpay_key_secret>
 # Optional — database name override
 MONGO_DB=<your_database_name>
 
+# Optional — Redis caching for products API
+REDIS_URL=                  # full connection string e.g. redis://localhost:6379
+REDIS_HOST=                 # or host-only e.g. localhost
+PRODUCTS_CACHE_TTL=60       # cache TTL in seconds (default: 60)
+
 # CORS
 ALLOWED_ORIGIN=http://localhost:5173    # comma-separate multiple origins
 

--- a/README.md
+++ b/README.md
@@ -373,13 +373,7 @@ React Router route guards using `useAuth` and `VITE_ADMIN_UID` to protect admin 
 Make sure you have the following installed:
 
 - [Node.js](https://nodejs.org/) v16+
-
-# Optional: Redis caching for products API
-# When set, the server will use Redis to cache product-list responses.
-# Use `REDIS_URL` for a full Redis connection string (e.g. redis://localhost:6379)
-# or `REDIS_HOST` for a host-only configuration. TTL (seconds) is configurable:
-# PRODUCTS_CACHE_TTL=60
-
+- [Redis](https://redis.io/) (optional) — for product API caching
 - [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
 - A [MongoDB](https://www.mongodb.com/atlas) connection (Atlas or local)
 - A [Firebase](https://firebase.google.com/) project (for auth)


### PR DESCRIPTION
## 📋 What does this PR do?
Redis env var details (REDIS_URL, REDIS_HOST, PRODUCTS_CACHE_TTL) were incorrectly placed in the Prerequisites section. Moved to server/.env block and replaced with a single bullet point.

## 🔗 Related Issue
Closes #456 

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys