### PR TITLE
fix: add min:0 schema constraint to stock and reserved fields

### DIFF
--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -13,7 +13,7 @@ const ProductSchema = new mongoose.Schema(
     badge: { type: String, default: null },
     image: { type: String, default: '' },
     // total stock available (optional). If null, stock is not enforced.
-    stock: { type: Number, default: 0, min: [0, 'Stock cannot be negative'] },
+    stock: { type: Number, default: null, min: [0, 'Stock cannot be negative'] },
     reserved: { type: Number, default: 0, min: [0, 'Reserved count cannot be negative'] }
   },
   { timestamps: true }

--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -13,9 +13,8 @@ const ProductSchema = new mongoose.Schema(
     badge: { type: String, default: null },
     image: { type: String, default: '' },
     // total stock available (optional). If null, stock is not enforced.
-    stock: { type: Number, default: null },
-    // quantity reserved by carts (sum of quantities currently in carts)
-    reserved: { type: Number, default: 0 },
+    stock: { type: Number, default: 0, min: [0, 'Stock cannot be negative'] },
+    reserved: { type: Number, default: 0, min: [0, 'Reserved count cannot be negative'] }
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## 📋 What does this PR do?
Adds `min: 0` schema-level validation to both `stock` and `reserved` fields 
in the Product schema to prevent negative values from being saved to the database.

## 🔗 Related Issue
Closes #354

## 🧪 How was this tested?
Verified that the schema change looks correct. The `min: [0, message]` syntax is 
standard Mongoose validation that throws a ValidationError if a negative 
value is attempted.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide.
- [x] My code follows the project's style guidelines.
- [x] I've linked the related issue.
- [x] I haven't introduced any new secrets or API keys.