### PR TITLE
fix: add functionality to homepage placeholder buttons

### DIFF
--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -632,7 +632,8 @@ export default function HomePage() {
                   </div>
                   <p className="text-sm text-stone-500 leading-relaxed">{p.desc}</p>
                 </div>
-                <button className="shrink-0 text-xs border border-stone-300 text-stone-700 px-5 py-2.5
+                <button   onClick={() => alert(`${cta} feature coming soon!`)}
+                className="shrink-0 text-xs border border-stone-300 text-stone-700 px-5 py-2.5
                                    rounded-full hover:bg-stone-900 hover:text-white hover:border-stone-900
                                    transition-all self-start min-h-10">
                   {p.cta}

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -592,10 +592,9 @@ export default function HomePage() {
                 Points for every purchase and every fitness milestone. Redeem against equipment, supplements, or coaching.
               </p>
             </div>
-            <button className="shrink-0 bg-stone-900 text-white text-sm px-6 sm:px-7 py-3 rounded-full
-                               hover:bg-stone-700 transition-colors self-start md:self-auto w-full sm:w-auto
-                               text-center">
-              Learn More
+           <button onClick={() => alert("Loyalty Program details coming soon!")}
+            className="shrink-0 bg-stone-900 text-white text-sm px-6 sm:px-7 py-3 rounded-full hover:bg-stone-700 transition-colors self-start md:self-auto w-full sm:w-auto text-center">
+            Learn More
             </button>
           </div>
         </section>
@@ -651,13 +650,16 @@ export default function HomePage() {
           <span className="font-['DM_Serif_Display'] text-lg text-stone-900">FitMart</span>
           <p className="text-xs text-stone-400 text-center">© 2026 FitMart. Built at VESIT, Mumbai.</p>
           <div className="flex gap-4 sm:gap-5">
-            {["Privacy", "Terms", "Support"].map(l => (
-              <button key={l}
-                className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1">
-                {l}
-              </button>
-            ))}
-          </div>
+  {["Privacy", "Terms", "Support"].map(l => (
+    <button
+      key={l}
+      onClick={() => alert(`${l} page coming soon!`)}
+      className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1"
+    >
+      {l}
+    </button>
+  ))}
+</div>
         </div>
       </footer>
 


### PR DESCRIPTION
Closes #348

Added click handlers to placeholder buttons on the HomePage.

Changes:
- Added interaction for Learn More button
- Added interaction for Upgrade to Pro button
- Added interaction for Upgrade to Elite button
- Added interaction for Privacy button
- Added interaction for Terms button
- Added interaction for Support button

Users now receive feedback instead of clicking non-functional buttons.