### PR TITLE
fix: wrap FitnessChatBot in ErrorBoundary to prevent UI crashes

### DIFF
--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -17,7 +17,7 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return <ErrorFallback />;
+      return this.props.fallback ?? <ErrorFallback />;
     }
 
     return this.props.children;

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -9,6 +9,7 @@ import CartDrawer from "../components/CartDrawer";
 import { fmt } from "../utils/formatters";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import FitnessChatBot from "../components/FitnessChatBot";
+import ErrorBoundary from "../components/ErrorBoundary";
 import WelcomeBanner from "../components/WelcomeBanner";
 import { useWelcomeDiscount } from "../auth/useWelcomeDiscount";
 import BMICalculator from "../components/BMICalculator";
@@ -666,7 +667,13 @@ export default function HomePage() {
         cart={cart} cartCount={cartCount} cartTotal={cartTotal}
         updateQty={updateQty} removeFromCart={removeFromCart}
       />
-      <FitnessChatBot />
+      <ErrorBoundary fallback={
+        <div className="fixed bottom-6 right-6 z-50 bg-white border border-stone-200 rounded-2xl px-4 py-3 text-xs text-stone-400 shadow-lg">
+          Chat unavailable
+        </div>
+      }>
+        <FitnessChatBot />
+      </ErrorBoundary>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #438

If the FitnessChatBot crashes due to a malformed API response, it currently brings down the entire page.

## Changes
- Added an optional `fallback` prop to `ErrorBoundary` so it can be used for scoped component-level error handling
- Wrapped `<FitnessChatBot />` in `HomePage.jsx` with a lightweight fallback that shows a small 'Chat unavailable' badge, keeping the rest of the page functional

## Files Changed
- `client/src/components/ErrorBoundary.jsx`
- `client/src/pages/HomePage.jsx`