### PR TITLE
feat: render markdown in bot messages using marked and DOMPurify

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,8 +13,10 @@
         "@fullcalendar/react": "^6.1.20",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/react-query": "^5.101.0",
+        "dompurify": "^3.4.8",
         "firebase": "^12.14.0",
         "framer-motion": "^12.40.0",
+        "marked": "^18.0.4",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.16.0",
@@ -2602,6 +2604,13 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -3059,6 +3068,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
+      "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4114,6 +4132,18 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/minimatch": {

--- a/client/package.json
+++ b/client/package.json
@@ -10,13 +10,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.101.0",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",
     "@fullcalendar/react": "^6.1.20",
     "@tailwindcss/vite": "^4.3.0",
+    "@tanstack/react-query": "^5.101.0",
+    "dompurify": "^3.4.8",
     "firebase": "^12.14.0",
     "framer-motion": "^12.40.0",
+    "marked": "^18.0.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.16.0",

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -1,4 +1,5 @@
 // src/components/FitnessChatBot.jsx
+import MarkdownMessage from "./MarkdownMessage";
 import { useState, useEffect, useRef } from "react";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
@@ -7,8 +8,6 @@ const WELCOME = {
   role: "bot",
   text: "Hello! I'm your FitMart fitness assistant. Ask me anything about workouts, diet, protein, weight loss, or muscle gain.",
 };
-
-
 
 const QUICK_REPLIES = [
   {
@@ -27,7 +26,7 @@ const QUICK_REPLIES = [
     label: "⚖️ Lose weight",
     prompt: "How do I lose weight sustainably?",
   },
-]
+];
 
 export default function FitnessChatBot() {
   const [open, setOpen] = useState(false);
@@ -104,57 +103,6 @@ export default function FitnessChatBot() {
     }
   };
 
-  const formatMessageText = (text) => {
-    const lines = text.split("\n");
-    return lines.map((line, lineIndex) => {
-      const parts = [];
-      const boldRegex = /\*\*(.*?)\*\*|__(.*?)__/g;
-      const matches = [];
-      let matchFound;
-      while ((matchFound = boldRegex.exec(line)) !== null) {
-        matches.push({
-          start: matchFound.index,
-          end: matchFound.index + matchFound[0].length,
-          text: matchFound[1] || matchFound[2],
-        });
-      }
-      if (matches.length === 0) {
-        parts.push(<span key={`line-${lineIndex}`}>{line}</span>);
-      } else {
-        let currentPos = 0;
-        matches.forEach((match, idx) => {
-          if (match.start > currentPos) {
-            parts.push(
-              <span key={`text-${lineIndex}-${idx}`}>
-                {line.substring(currentPos, match.start)}
-              </span>
-            );
-          }
-          parts.push(
-            <strong key={`bold-${lineIndex}-${idx}`}
-              className="font-semibold text-stone-900">
-              {match.text}
-            </strong>
-          );
-          currentPos = match.end;
-        });
-        if (currentPos < line.length) {
-          parts.push(
-            <span key={`text-${lineIndex}-end`}>
-              {line.substring(currentPos)}
-            </span>
-          );
-        }
-      }
-      return (
-        <span key={lineIndex}>
-          {parts}
-          {lineIndex < lines.length - 1 && <br />}
-        </span>
-      );
-    });
-  };
-
   return (
     <>
       <style>{`
@@ -198,18 +146,14 @@ export default function FitnessChatBot() {
       `}</style>
 
       {/* ── Chat Window ── */}
-      {/* Full-screen on mobile, fixed-size floating window on sm+ */}
       <div
         className={`fm-chat-window fixed z-50 bg-white border border-stone-200
                     shadow-2xl flex flex-col overflow-hidden
-                    /* Mobile: full screen minus FAB area */
                     bottom-20 right-3 left-3 rounded-2xl
-                    /* sm+: floating panel anchored to bottom-right */
                     sm:bottom-24 sm:right-5 sm:left-auto sm:w-90
                     ${open ? "open" : "closed"}`}
         style={{
           fontFamily: "'DM Sans', sans-serif",
-          /* Mobile height fills available space; fixed on sm+ */
           height: "calc(100vh - 6rem)",
           maxHeight: "520px",
         }}
@@ -269,12 +213,14 @@ export default function FitnessChatBot() {
                       : "bg-white border border-stone-200 text-stone-700 rounded-bl-sm shadow-sm"
                   }`}
               >
-                {formatMessageText(msg.text)}
+                {msg.role === "bot" ? (
+                  <MarkdownMessage content={msg.text} />
+                ) : (
+                  <span>{msg.text}</span>
+                )}
               </div>
             </div>
           ))}
-
-
 
           {/* Typing Indicator */}
           {typing && (
@@ -297,8 +243,7 @@ export default function FitnessChatBot() {
 
         <div className="h-px bg-stone-100 shrink-0" />
 
-        {/*  Show quick replies only before the conversation starts
-         to keep the chat area clean after interaction begins */}
+        {/* Quick Replies */}
         {msgs.length === 1 && (
           <div className="flex gap-2 overflow-x-auto whitespace-nowrap pb-1 scrollbar-hide">
             {QUICK_REPLIES.map((reply) => (
@@ -323,12 +268,10 @@ export default function FitnessChatBot() {
             onKeyDown={onKeyDown}
             placeholder="Ask about workouts, diet, protein…"
             disabled={typing}
-            className="flex-1 min-w-0  resize-none border border-stone-200 bg-stone-50 rounded-xl
+            className="flex-1 min-w-0 resize-none border border-stone-200 bg-stone-50 rounded-xl
                        px-3.5 sm:px-4 py-2.5 text-sm text-stone-900 placeholder-stone-300
                        focus:outline-none focus:border-stone-900 transition-colors
                        disabled:opacity-50 leading-relaxed"
-            // min-w-0 allows the textarea to shrink correctly
-            // inside flex layouts and prevents layout overflow
             style={{ maxHeight: "96px", overflowY: "hidden" }}
             onInput={(e) => {
               e.target.style.height = "auto";
@@ -336,8 +279,6 @@ export default function FitnessChatBot() {
             }}
           />
           <button
-            // Wrap send() in an arrow function to avoid
-            // React automatically passing the click event object
             onClick={() => send()}
             disabled={!input.trim() || typing}
             className="w-10 h-10 sm:w-9 sm:h-9 bg-stone-900 text-white rounded-full

--- a/client/src/components/MarkdownMessage.jsx
+++ b/client/src/components/MarkdownMessage.jsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { renderMarkdown } from "../utils/markdown";
+
+const MarkdownMessage = ({ content }) => {
+  return (
+    <div
+      className="fm-bot-content"
+      dangerouslySetInnerHTML={{
+        __html: renderMarkdown(content),
+      }}
+    />
+  );
+};
+
+export default MarkdownMessage;

--- a/client/src/utils/markdown.js
+++ b/client/src/utils/markdown.js
@@ -1,0 +1,24 @@
+import { marked } from "marked";
+import DOMPurify from "dompurify";
+
+marked.setOptions({
+  gfm: true,
+  breaks: true,
+});
+
+export const renderMarkdown = (content) => {
+  try {
+    const html = marked.parse(content || "");
+    return DOMPurify.sanitize(html, {
+      ALLOWED_TAGS: [
+        "p", "br", "strong", "em", "ul", "ol", "li", 
+        "code", "pre", "blockquote", "hr", 
+        "h1", "h2", "h3", "h4", "h5", "h6", "a"
+      ],
+      ALLOWED_ATTR: ["href", "target", "rel"]
+    });
+  } catch (error) {
+    console.error("Markdown rendering failed:", error);
+    return DOMPurify.sanitize(`<p>${String(content || "")}</p>`);
+  }
+};


### PR DESCRIPTION
## 📋 What does this PR do?
This PR fixes the issue where bot messages display raw markdown tags like asterisks and dashes by introducing a sanitized markdown renderer using marked and DOMPurify.

## 🔗 Related Issue
Closes #<397>

## 🧪 How was this tested?
Ran `npm run dev` inside the client folder.
- Opened the chatbot interface locally and sent messages to trigger bold strings and bulleted recommendations.
- Verified everything displays cleanly with proper spacing and indentation.
- Tested an XSS payload to ensure the input is completely sanitized by DOMPurify.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys