### PR TITLE
Refactor: Standardize error formats across authentication middleware

### DIFF
--- a/server/middleware/verifyAdmin.js
+++ b/server/middleware/verifyAdmin.js
@@ -6,7 +6,7 @@ const isDev = process.env.NODE_ENV !== 'production';
 
 const verifyAdmin = (req, res, next) => {
   if (!req.user) {
-    return res.status(401).json({ error: 'Unauthorized — no user found' });
+    return res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Unauthorized — no user found' } });
   }
 
   // Production check: match UIDs
@@ -21,7 +21,7 @@ const verifyAdmin = (req, res, next) => {
     if (process.env.DEV_ADMIN_UID && req.user.uid === process.env.DEV_ADMIN_UID) return next();
   }
 
-  return res.status(403).json({ error: 'Forbidden — admin access required' });
+  return res.status(403).json({ success: false, error: { code: 'FORBIDDEN', message: 'Forbidden — admin access required' } });
 };
 
 module.exports = verifyAdmin;

--- a/server/middleware/verifyFirebaseToken.js
+++ b/server/middleware/verifyFirebaseToken.js
@@ -12,7 +12,7 @@ const verifyFirebaseToken = async (req, res, next) => {
   const authHeader = req.headers.authorization;
 
   if (!authHeader?.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'Unauthorized — no token provided' });
+    return res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Unauthorized — no token provided' } });
   }
 
   const token = authHeader.split('Bearer ')[1];
@@ -30,13 +30,13 @@ const verifyFirebaseToken = async (req, res, next) => {
 
     // Allow the super-admin UID to bypass email verification
     if (!decoded.email_verified && decoded.uid !== SUPER_ADMIN_UID) {
-      return res.status(403).json({ error: 'Forbidden — email not verified' });
+      return res.status(403).json({ success: false, error: { code: 'FORBIDDEN', message: 'Forbidden — email not verified' } });
     }
 
     req.user = decoded;
     next();
   } catch (err) {
-    return res.status(401).json({ error: 'Unauthorized — invalid or expired token' });
+    return res.status(401).json({ success: false, error: { code: 'UNAUTHORIZED', message: 'Unauthorized — invalid or expired token' } });
   }
 };
 


### PR DESCRIPTION
Closes #512

## Summary
Standardized all 401/403 error responses in the authentication middleware to return a consistent JSON format.

## Changes
- **`server/middleware/verifyFirebaseToken.js`** — Updated 3 error responses (2x 401, 1x 403) to use `{ success: false, error: { code: "UNAUTHORIZED"|"FORBIDDEN", message: "..." } }`
- **`server/middleware/verifyAdmin.js`** — Updated 2 error responses (1x 401, 1x 403) to use the same standardized format

## Before
```json
{ "error": "Unauthorized — no token provided" }
```

## After
```json
{ "success": false, "error": { "code": "UNAUTHORIZED", "message": "Unauthorized — no token provided" } }
```