### PR TITLE
test: add unit tests for resolveFirebaseUser utility

### DIFF
--- a/server/tests/resolveFirebaseUser.test.js
+++ b/server/tests/resolveFirebaseUser.test.js
@@ -1,0 +1,85 @@
+const { getAuth } = require('firebase-admin/auth');
+
+jest.mock('firebase-admin/auth', () => ({
+  getAuth: jest.fn(),
+}));
+
+const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
+
+describe('resolveFirebaseUser', () => {
+  const mockGetUser = jest.fn();
+
+  beforeAll(() => {
+    getAuth.mockReturnValue({ getUser: mockGetUser });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('returns standardized user object when user has all fields', async () => {
+    const rawUser = {
+      displayName: 'John Doe',
+      photoURL: 'https://example.com/photo.jpg',
+      email: 'john@example.com',
+    };
+    mockGetUser.mockResolvedValueOnce(rawUser);
+
+    const result = await resolveFirebaseUser('uid-1');
+
+    expect(result).toEqual({
+      displayName: 'John Doe',
+      photoURL: 'https://example.com/photo.jpg',
+      email: 'john@example.com',
+    });
+    expect(mockGetUser).toHaveBeenCalledWith('uid-1');
+  });
+
+  test('falls back to em dash for missing displayName', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      displayName: null,
+      photoURL: 'https://example.com/photo.jpg',
+      email: 'john@example.com',
+    });
+
+    const result = await resolveFirebaseUser('uid-2');
+
+    expect(result.displayName).toBe('—');
+  });
+
+  test('falls back to em dash for missing email', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      displayName: 'John Doe',
+      photoURL: 'https://example.com/photo.jpg',
+      email: undefined,
+    });
+
+    const result = await resolveFirebaseUser('uid-3');
+
+    expect(result.email).toBe('—');
+  });
+
+  test('returns null for missing photoURL', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      displayName: 'John Doe',
+      photoURL: null,
+      email: 'john@example.com',
+    });
+
+    const result = await resolveFirebaseUser('uid-4');
+
+    expect(result.photoURL).toBeNull();
+  });
+
+  test('returns fallback object when getUser throws an error', async () => {
+    mockGetUser.mockRejectedValueOnce(new Error('User not found'));
+
+    const result = await resolveFirebaseUser('nonexistent-uid');
+
+    expect(result).toEqual({
+      displayName: '—',
+      photoURL: null,
+      email: '—',
+    });
+  });
+});


### PR DESCRIPTION
Closes #514

## Summary
Adds comprehensive Jest unit tests for the `resolveFirebaseUser` utility function, which was recently refactored to standardize user object keys.

## Changes
- **Created `server/tests/resolveFirebaseUser.test.js`** — 5 test cases covering:
  - Returns standardized user object when all fields (displayName, photoURL, email) are present
  - Falls back to "—" for missing `displayName`
  - Falls back to "—" for missing `email`
  - Returns `null` for missing `photoURL`
  - Returns fallback object when `getUser` throws an error

## Test Results
```
PASS  tests/resolveFirebaseUser.test.js
  resolveFirebaseUser
    ✓ returns standardized user object when user has all fields
    ✓ falls back to em dash for missing displayName
    ✓ falls back to em dash for missing email
    ✓ returns null for missing photoURL
    ✓ returns fallback object when getUser throws an error

Tests:   5 passed, 5 total
```