### PR TITLE
fix: prevent negative stock via atomic inventory update

### DIFF
--- a/server/services/orderService.js
+++ b/server/services/orderService.js
@@ -1,7 +1,7 @@
 // server/services/orderService.js
-const Order = require('../models/Order');
-const Cart = require('../models/Cart');
-const Product = require('../models/Product');
+const Order = require("../models/Order");
+const Cart = require("../models/Cart");
+const Product = require("../models/Product");
 
 /**
  * Creates an order from explicit items or the user's cart.
@@ -19,9 +19,12 @@ async function createOrder(userId, items = null) {
   if (!orderItems || !orderItems.length) {
     const cart = await Cart.findOne({ userId });
     if (!cart || !cart.items.length) {
-      throw new Error('Cart is empty');
+      throw new Error("Cart is empty");
     }
-    orderItems = cart.items.map(i => ({ productId: i.productId, quantity: i.quantity }));
+    orderItems = cart.items.map((i) => ({
+      productId: i.productId,
+      quantity: i.quantity,
+    }));
   }
 
   // Build order items with price snapshot
@@ -38,11 +41,17 @@ async function createOrder(userId, items = null) {
     if (p.stock !== null) {
       const available = p.stock - (p.reserved || 0);
       if (available < it.quantity) {
-        throw new Error(`Insufficient stock for ${p.name}. Available: ${available}`);
+        throw new Error(
+          `Insufficient stock for ${p.name}. Available: ${available}`,
+        );
       }
     }
 
-    populated.push({ productId: p.productId, quantity: it.quantity, price: p.price });
+    populated.push({
+      productId: p.productId,
+      quantity: it.quantity,
+      price: p.price,
+    });
     total += p.price * it.quantity;
   }
 
@@ -56,14 +65,24 @@ async function createOrder(userId, items = null) {
       // Safely calculate new reserved to avoid negative values
       const currentReserved = Number(p.reserved || 0);
       const newReserved = Math.max(0, currentReserved - it.quantity);
-      
-      await Product.findOneAndUpdate(
-        { productId: p.productId },
-        { 
+
+      const updatedProduct = await Product.findOneAndUpdate(
+        {
+          productId: p.productId,
+          stock: { $gte: it.quantity },
+        },
+        {
           $inc: { stock: -it.quantity },
-          $set: { reserved: newReserved }
-        }
+          $set: { reserved: newReserved },
+        },
+        {
+          new: true,
+        },
       );
+
+      if (!updatedProduct) {
+        throw new Error(`Insufficient stock for ${p.name}`);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #351

Replaced stock decrement operation with an atomic
findOneAndUpdate() using a stock precondition filter.

Before:
- Stock availability was checked separately.
- Multiple concurrent orders could pass validation.
- Stock could become negative.

After:
- MongoDB validates stock >= quantity and decrements stock
  in a single atomic operation.
- Prevents overselling and negative stock values.
- Returns an error when stock becomes insufficient.