### PR TITLE
UX/Performance: Paginate the FitRewards transaction history

### DIFF
--- a/client/src/hooks/useInfiniteTransactions.js
+++ b/client/src/hooks/useInfiniteTransactions.js
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { getAuthHeaders } from "../utils/getAuthHeaders";
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+
+async function fetchTransactions({ pageParam = null, queryKey }) {
+  const [_key, { userId }] = queryKey;
+  const headers = await getAuthHeaders();
+  const url = new URL(`${API}/api/rewards/${userId}`);
+  if (pageParam) url.searchParams.set("cursor", pageParam);
+  url.searchParams.set("limit", "20");
+  const res = await fetch(url.toString(), { headers, credentials: "include" });
+  if (!res.ok) throw new Error("Failed to fetch transactions");
+  return res.json();
+}
+
+export default function useInfiniteTransactions(userId) {
+  return useInfiniteQuery({
+    queryKey: ["rewards-transactions", { userId }],
+    queryFn: fetchTransactions,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage?.pagination?.hasMore) return undefined;
+      return lastPage.pagination.nextCursor;
+    },
+    enabled: !!userId,
+    staleTime: 1000 * 60 * 2,
+    retry: 2,
+  });
+}

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -12,6 +12,7 @@ import {
   getTransactionIcon,
 } from "../utils/rewardsUtils";
 import Navbar from "../components/Navbar";
+import useInfiniteTransactions from "../hooks/useInfiniteTransactions";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -128,9 +129,17 @@ export default function Profile() {
   const [photoURL, setPhotoURL] = useState(null);
   const [orders, setOrders] = useState([]);
   const [loadingOrders, setLoadingOrders] = useState(false);
-  const [rewardsData, setRewardsData] = useState(null);
-const [rewardsLoading, setRewardsLoading] = useState(false);
-const [rewardsError, setRewardsError] = useState("");
+const user = auth.currentUser;
+  const {
+    data: rewardsInfiniteData,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: infiniteRewardsLoading,
+    error: infiniteRewardsError,
+  } = useInfiniteTransactions(
+    activeTab === "fitrewards" ? user?.uid : undefined
+  );
 
   useEffect(() => { document.title = "Profile – FitMart"; }, []);
 
@@ -162,36 +171,7 @@ const [rewardsError, setRewardsError] = useState("");
     });
     return () => unsub();
   }, [navigate]);
-    const fetchRewardsData = async () => {
-    try {
-      setRewardsLoading(true);
-      setRewardsError("");
-
-      const headers = await getAuthHeaders();
-
-      const response = await fetch(`${API}/api/rewards/me`, {
-        headers,
-        credentials: "include",
-      });
-
-      if (!response.ok) {
-        throw new Error("Failed to fetch rewards data");
-      }
-
-      const data = await response.json();
-      setRewardsData(data);
-    } catch (error) {
-      setRewardsError(error.message || "Could not load FitRewards");
-    } finally {
-      setRewardsLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    if (activeTab === "fitrewards" && !rewardsData) {
-      fetchRewardsData();
-    }
-  }, [activeTab]);
+    // rewards fetching is now managed by useInfiniteTransactions hook
 
   // Fetch orders when orders tab is active
   useEffect(() => {
@@ -517,9 +497,12 @@ const [rewardsError, setRewardsError] = useState("");
                 {/* ── FITREWARDS TAB ── */}
         {activeTab === "fitrewards" && (
           <FitRewardsTab
-            rewardsData={rewardsData}
-            rewardsLoading={rewardsLoading}
-            rewardsError={rewardsError}
+            rewardsInfiniteData={rewardsInfiniteData}
+            rewardsLoading={infiniteRewardsLoading}
+            rewardsError={infiniteRewardsError}
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
           />
         )}
 
@@ -722,7 +705,14 @@ const [rewardsError, setRewardsError] = useState("");
     </div>
   );
 }
-const FitRewardsTab = ({ rewardsData, rewardsLoading, rewardsError }) => {
+const FitRewardsTab = ({
+  rewardsInfiniteData,
+  rewardsLoading,
+  rewardsError,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+}) => {
   if (rewardsLoading) {
     return (
       <div className="space-y-6">
@@ -758,18 +748,23 @@ const FitRewardsTab = ({ rewardsData, rewardsLoading, rewardsError }) => {
   if (rewardsError) {
     return (
       <div className="rounded-3xl border border-stone-200 bg-white p-6 text-stone-700">
-        {rewardsError}
+        {rewardsError?.message || String(rewardsError)}
       </div>
     );
   }
 
+  // Extract the first page for the rewards summary (points, tier)
+  const firstPage = rewardsInfiniteData?.pages?.[0];
+
   const points =
-    rewardsData?.points ??
-    rewardsData?.balance ??
-    rewardsData?.currentPoints ??
+    firstPage?.points ??
+    firstPage?.pointsBalance ??
+    firstPage?.currentPoints ??
     0;
 
-  const transactions = rewardsData?.transactions || [];
+  // Flatten transactions from all pages
+  const transactions =
+    rewardsInfiniteData?.pages?.flatMap((p) => p.transactions) || [];
 
   const { currentTier } = getRewardTier(points);
   const tierProgress = getTierProgress(points);
@@ -848,6 +843,19 @@ const FitRewardsTab = ({ rewardsData, rewardsLoading, rewardsError }) => {
                 </p>
               </div>
             ))}
+
+            {/* Load More button */}
+            {hasNextPage && (
+              <div className="pt-2 text-center">
+                <button
+                  onClick={() => fetchNextPage()}
+                  disabled={isFetchingNextPage}
+                  className="border border-stone-200 text-stone-700 text-sm px-6 py-2.5 rounded-full hover:bg-stone-900 hover:text-white hover:border-stone-900 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {isFetchingNextPage ? "Loading…" : "Load More"}
+                </button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/server/routes/rewards.js
+++ b/server/routes/rewards.js
@@ -36,6 +36,8 @@ function calculatePoints(source, amount = 0) {
 router.get("/:userId", verifyFirebaseToken, async (req, res) => {
   try {
     const { userId } = req.params;
+    const { cursor, limit: queryLimit } = req.query;
+    const limit = Math.min(Math.max(parseInt(queryLimit) || 20, 1), 100);
 
     let rewards = await Rewards.findOne({ userId });
 
@@ -47,15 +49,38 @@ router.get("/:userId", verifyFirebaseToken, async (req, res) => {
       });
     }
 
-    const transactions = [...rewards.transactions].sort(
+    // Sort transactions newest-first
+    const sorted = [...rewards.transactions].sort(
       (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
     );
+
+    // Cursor-based pagination: find the index after the cursor transaction
+    let startIndex = 0;
+    if (cursor) {
+      const cursorIndex = sorted.findIndex(
+        (t) => t._id && t._id.toString() === cursor
+      );
+      if (cursorIndex !== -1) {
+        startIndex = cursorIndex + 1;
+      }
+    }
+
+    const pagedTransactions = sorted.slice(startIndex, startIndex + limit);
+    const hasMore = startIndex + limit < sorted.length;
+    const nextCursor =
+      pagedTransactions.length > 0
+        ? pagedTransactions[pagedTransactions.length - 1]._id.toString()
+        : null;
 
     return res.status(200).json({
       userId: rewards.userId,
       pointsBalance: rewards.pointsBalance,
       tier: getTier(rewards.pointsBalance),
-      transactions,
+      transactions: pagedTransactions,
+      pagination: {
+        hasMore,
+        nextCursor,
+      },
     });
   } catch (error) {
     console.error("Get rewards error:", error);


### PR DESCRIPTION
Closes #526

## Summary
Add cursor-based pagination to the FitRewards transaction history to prevent performance degradation as users accumulate hundreds of transactions.

## Backend Changes
- **`server/routes/rewards.js`** — Updated `GET /api/rewards/:userId` to accept optional `cursor` and `limit` query parameters. Returns paginated transactions along with a `pagination` object containing `hasMore` and `nextCursor` fields. Default limit is 20, max is 100.

## Frontend Changes
- **`client/src/hooks/useInfiniteTransactions.js`** — New hook using `@tanstack/react-query`'s `useInfiniteQuery` (similar to the existing `useInfiniteProducts` pattern). Fetches paginated rewards data using cursor-based navigation.
- **`client/src/pages/Profile.jsx`** — Replaced the manual `fetchRewardsData` function + state with the new hook. Updated `FitRewardsTab` to flatten transactions from all pages and display a "Load More" button when more pages are available.