### PR TITLE
fix: correct YAML syntax in welcome.yml workflow

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,22 +1,17 @@
 name: Welcome Bot
 
 on:
-issues:
-types: [opened]
-
-pull_request_target:
-types: [opened, closed]
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened, closed]
 
 jobs:
-welcome:
-runs-on: ubuntu-latest
-
-```
-steps:
-  - uses: actions/checkout@v4
-
-  - uses: behaviorbot/welcome@v1
-    with:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CONFIG_FILE: .github/config.yml
-```
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: behaviorbot/welcome@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONFIG_FILE: .github/config.yml


### PR DESCRIPTION
The welcome.yml GitHub Actions workflow had broken YAML syntax which caused the workflow runner to fail with "No jobs were run". The issues were:

- Incorrect indentation under `on:` triggers
- Markdown code block markers (` ``` `) embedded inside the YAML file
- Missing indentation in the `jobs:` definition

This PR fixes the formatting so GitHub Actions can parse the workflow correctly.