### PR TITLE
refactor: remove deprecated mongoose connection options

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -13,7 +13,7 @@ mongoose.set('strictQuery', true);
 
 async function connect() {
   try {
-    await mongoose.connect(MONGO_URI, MONGO_DB ? { dbName: MONGO_DB } : {});
+    await mongoose.connect(MONGO_URI);
     console.log("MongoDB connected successfully");
   } catch (err) {
     console.error("MongoDB connection failed:", err.message);


### PR DESCRIPTION
Fixes #355
Removed deprecated useNewUrlParser and useUnifiedTopology options from mongoose.connect() in server/db.js. These options have been no-ops since Mongoose 6.x and generate deprecation warnings on startup.
Change: Simplified mongoose.connect(MONGO_URI, { ... }) → mongoose.connect(MONGO_URI)