### PR TITLE
refactor: remove duplicate Google Fonts imports

### DIFF
--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -162,8 +162,7 @@ export default function FitnessChatBot() {
   return (
     <>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display&display=swap');
-        .fm-chat-window {
+        
           transform-origin: bottom right;
           transition: opacity 0.25s ease, transform 0.25s cubic-bezier(0.16, 1, 0.3, 1);
         }

--- a/client/src/pages/AdminBugs.jsx
+++ b/client/src/pages/AdminBugs.jsx
@@ -170,9 +170,7 @@ export default function AdminBugs() {
 
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-      <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
-      `}</style>
+     
 
       <AdminNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
 

--- a/client/src/pages/AdminCustomerDetail.jsx
+++ b/client/src/pages/AdminCustomerDetail.jsx
@@ -280,9 +280,7 @@ export default function AdminCustomerDetail() {
 
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-      <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
-      `}</style>
+    
 
       <AdminNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
 

--- a/client/src/pages/AdminCustomers.jsx
+++ b/client/src/pages/AdminCustomers.jsx
@@ -193,9 +193,7 @@ export default function AdminCustomers() {
 
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
-      <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
-      `}</style>
+     
 
       <AdminNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
 

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -159,7 +159,6 @@ export default function AdminDashboard() {
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <AdminNavbar range={range} setRange={setRange} menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
         .fitmart-chart .recharts-cartesian-grid-horizontal line,
         .fitmart-chart .recharts-cartesian-grid-vertical line { stroke: #e7e5e3; }
         .fitmart-chart .recharts-tooltip-cursor { fill: #f5f5f4; }

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -224,7 +224,7 @@ export default function AdminInventory() {
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-in { animation: fmFade 0.5s ease forwards; }
         @keyframes fmFade { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
       `}</style>

--- a/client/src/pages/AdminMarketing.jsx
+++ b/client/src/pages/AdminMarketing.jsx
@@ -130,7 +130,7 @@ export default function AdminMarketing() {
     >
       <AdminNavbar menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+       
         .fade-in { animation: fmFadeIn 0.5s ease forwards; }
         @keyframes fmFadeIn { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
       `}</style>

--- a/client/src/pages/AdminReports.jsx
+++ b/client/src/pages/AdminReports.jsx
@@ -119,7 +119,7 @@ export default function AdminReports() {
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-in { animation: fmFade 0.5s ease forwards; }
         @keyframes fmFade { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
       `}</style>

--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -256,7 +256,7 @@ export default function Authentication() {
   return (
     <div className="min-h-screen bg-stone-50 font-['DM_Sans',sans-serif] flex flex-col lg:flex-row">
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+       
         .auth-panel { opacity: 0; transform: translateY(20px); transition: opacity 0.6s ease, transform 0.6s ease; }
         .auth-panel.visible { opacity: 1; transform: translateY(0); }
         .input-field { transition: border-color 0.2s ease; }

--- a/client/src/pages/Checkout.jsx
+++ b/client/src/pages/Checkout.jsx
@@ -142,9 +142,7 @@ export default function Checkout() {
 
   return (
     <PageShell menuOpen={menuOpen} setMenuOpen={setMenuOpen}>
-      <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display&display=swap');
-      `}</style>
+     
 
       <div className="max-w-7xl mx-auto px-4 sm:px-5 lg:px-10 py-8 sm:py-12">
 

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -406,7 +406,7 @@ export default function HomePage() {
         <script type="application/ld+json">{JSON.stringify(jsonLd)}</script>
       )}
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-in { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-in.show { opacity:1; transform:translateY(0); }
         .d1{transition-delay:.05s} .d2{transition-delay:.15s} .d3{transition-delay:.25s}

--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -151,7 +151,7 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen bg-white font-['DM_Sans',sans-serif] overflow-x-hidden">
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-up { opacity:0; transform:translateY(28px); transition:opacity .7s ease,transform .7s ease; }
         .fade-up.visible { opacity:1; transform:translateY(0); }
         .delay-1 { transition-delay:.1s; }

--- a/client/src/pages/LegalPrivacy.jsx
+++ b/client/src/pages/LegalPrivacy.jsx
@@ -33,7 +33,7 @@ const PrivacyPolicy = () => {
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-up { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-up.visible { opacity:1; transform:translateY(0); }
         .delay-1 { transition-delay: 100ms; }

--- a/client/src/pages/LegalTerms.jsx
+++ b/client/src/pages/LegalTerms.jsx
@@ -29,7 +29,7 @@ const TermsAndConditions = () => {
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-up { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-up.visible { opacity:1; transform:translateY(0); }
         .delay-1 { transition-delay: 100ms; }

--- a/client/src/pages/MobilityRecoveryPlans.jsx
+++ b/client/src/pages/MobilityRecoveryPlans.jsx
@@ -60,7 +60,7 @@ export default function MobilityRecoveryPlans() {
   return (
     <div className="min-h-screen bg-stone-50 font-['DM_Sans',sans-serif]">
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+       
         .fade-in { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-in.show { opacity:1; transform:translateY(0); }
         .d1{transition-delay:.05s} .d2{transition-delay:.15s} .d3{transition-delay:.25s} .d4{transition-delay:.35s}

--- a/client/src/pages/MuscleBuildingPlans.jsx
+++ b/client/src/pages/MuscleBuildingPlans.jsx
@@ -60,7 +60,7 @@ export default function MuscleBuildingPlans() {
   return (
     <div className="min-h-screen bg-stone-50 font-['DM_Sans',sans-serif]">
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+       
         .fade-in { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-in.show { opacity:1; transform:translateY(0); }
         .d1{transition-delay:.05s} .d2{transition-delay:.15s} .d3{transition-delay:.25s} .d4{transition-delay:.35s}

--- a/client/src/pages/PaymentPage.jsx
+++ b/client/src/pages/PaymentPage.jsx
@@ -300,9 +300,7 @@ export default function PaymentPage() {
         setMenuOpen={setMenuOpen}
       />
 
-      <style>
-        {`@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display&display=swap');`}
-      </style>
+      
 
       <div className="max-w-xl mx-auto px-4 sm:px-5 py-10 sm:py-16">
         <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-2 sm:mb-3">

--- a/client/src/pages/ProductConfirmation.jsx
+++ b/client/src/pages/ProductConfirmation.jsx
@@ -598,7 +598,7 @@ const currentOrderTime = now.toLocaleTimeString("en-IN", {
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display&display=swap');
+    
         .fade-up {
           opacity: 0;
           transform: translateY(28px);

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -230,7 +230,7 @@ export default function ProductPage() {
     <>
       <Shell cartCount={cartCount} onCartOpen={() => setCartOpen(true)}>
         <style>{`
-          @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+          
           .pd-fade { opacity:0; transform:translateY(20px); transition:opacity .6s ease,transform .6s ease; }
           .pd-fade.in { opacity:1; transform:translateY(0); }
           .pd-fade-img { opacity:0; transition:opacity .5s ease; }

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -342,7 +342,7 @@ const [rewardsError, setRewardsError] = useState("");
   return (
     <div className="min-h-screen bg-stone-50" style={{ fontFamily: "'DM Sans', sans-serif" }}>
       <Navbar variant="home" menuOpen={menuOpen} setMenuOpen={setMenuOpen} />
-      <style>{`@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display&display=swap');`}</style>
+      
 
       {toast && <Toast message={toast} onClose={() => setToast(null)} />}
 

--- a/client/src/pages/WeightLossPlans.jsx
+++ b/client/src/pages/WeightLossPlans.jsx
@@ -62,7 +62,7 @@ export default function WeightLossPlans() {
   return (
     <div className="min-h-screen bg-stone-50 font-['DM_Sans',sans-serif]">
       <style>{`
-        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
+        
         .fade-in { opacity:0; transform:translateY(16px); transition:opacity .5s ease,transform .5s ease; }
         .fade-in.show { opacity:1; transform:translateY(0); }
         .d1{transition-delay:.05s} .d2{transition-delay:.15s}


### PR DESCRIPTION
## Summary

* Removed duplicate Google Fonts imports from multiple components and pages.
* Kept the font import centralized in `client/src/index.css`.
* Reduced code duplication and improved maintainability.

## Changes Made

* Removed inline Google Fonts `@import` statements from affected React components/pages.
* Retained the global font import in `client/src/index.css`.

## Issue

Fixes #361
