### PR TITLE
Refactor: Remove redundant try/catch blocks across backend routes (Express 5)

### DIFF
--- a/server/routes/bugs.js
+++ b/server/routes/bugs.js
@@ -23,7 +23,6 @@ const upload = multer({
 
 // ── POST /api/bugs — public, accepts optional screenshot ──────────────────
 router.post('/', upload.single('screenshot'), async (req, res) => {
-  try {
     const { title, description, steps, pageUrl, browser } = req.body;
     let { reporterName, reporterEmail } = req.body;
 
@@ -89,26 +88,16 @@ router.post('/', upload.single('screenshot'), async (req, res) => {
 
     await bug.save();
     res.status(201).json({ ok: true, bug });
-  } catch (err) {
-    console.error('Error saving bug:', err);
-    res.status(500).json({ error: 'Failed to submit bug' });
-  }
-});
+  });
 
 // ── GET /api/bugs — admin only ────────────────────────────────────────────
 router.get('/', verifyFirebaseToken, verifyAdmin, async (_req, res) => {
-  try {
     const bugs = await Bug.find().sort({ createdAt: -1 }).limit(500);
     res.json({ ok: true, bugs });
-  } catch (err) {
-    console.error('Error fetching bugs:', err);
-    res.status(500).json({ error: 'Failed to fetch bugs' });
-  }
-});
+  });
 
 // ── PATCH /api/bugs/:id — admin only ─────────────────────────────────────
 router.patch('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
 
     const { status } = req.body;
     if (!['open', 'in-progress', 'resolved'].includes(status))
@@ -117,10 +106,6 @@ router.patch('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const bug = await Bug.findByIdAndUpdate(req.params.id, { status }, { new: true });
     if (!bug) return res.status(404).json({ error: 'Not found' });
     res.json({ ok: true, bug });
-  } catch (err) {
-    console.error('Error updating bug:', err);
-    res.status(500).json({ error: 'Failed to update bug' });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -83,17 +83,13 @@ function checkOwnership(req, res) {
 router.get('/:userId', verifyFirebaseToken, async (req, res) => {
   if (!checkOwnership(req, res)) return;
 
-  try {
     const { userId } = req.params;
     let cart = await Cart.findOne({ userId });
     if (!cart) {
       cart = await Cart.create({ userId, items: [] });
     }
     res.json(cart);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   POST /api/cart/:userId/add
@@ -103,7 +99,6 @@ router.get('/:userId', verifyFirebaseToken, async (req, res) => {
 router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
   if (!checkOwnership(req, res)) return;
 
-  try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
     if (productId == null || quantity == null) return res.status(400).json({ error: 'productId and quantity required' });
@@ -131,11 +126,7 @@ router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
     await cart.save();
     const fresh = await Cart.findOne({ userId });
     res.json(fresh);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   POST /api/cart/:userId/remove
@@ -145,7 +136,6 @@ router.post('/:userId/add', verifyFirebaseToken, async (req, res) => {
 router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
   if (!checkOwnership(req, res)) return;
 
-  try {
     const { userId } = req.params;
     const { productId, quantity } = req.body;
     if (productId == null || quantity == null) return res.status(400).json({ error: 'productId and quantity required' });
@@ -167,11 +157,7 @@ router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
     await cart.save();
     const fresh = await Cart.findOne({ userId });
     res.json(fresh);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   DELETE /api/cart/:userId
@@ -181,7 +167,6 @@ router.post('/:userId/remove', verifyFirebaseToken, async (req, res) => {
 router.delete('/:userId', verifyFirebaseToken, async (req, res) => {
   if (!checkOwnership(req, res)) return;
 
-  try {
     const { userId } = req.params;
     const cart = await Cart.findOne({ userId });
     if (!cart) return res.status(404).json({ error: 'Cart not found' });
@@ -193,10 +178,6 @@ router.delete('/:userId', verifyFirebaseToken, async (req, res) => {
     cart.items = [];
     await cart.save();
     res.json({ success: true });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -91,7 +91,6 @@ const chatSchema = z.object({
 }).strict();
 
 router.post("/", chatLimiter, async (req, res) => {
-  try {
     // Request validation (from origin/main)
     if (!req.body || typeof req.body !== 'object') {
       return res.status(400).json({ error: 'Invalid request', details: ['body: JSON object expected'] });
@@ -182,11 +181,11 @@ router.post("/", chatLimiter, async (req, res) => {
       console.error("Error Status:", apiError.status);
 
       if (apiError.status === 429) {
-        console.warn("⚠️ API quota exceeded, using fallback response");
+        console.warn("API quota exceeded, using fallback response");
         reply = getFallbackResponse(message);
         usedFallback = true;
       } else if (apiError.message?.includes("API key")) {
-        console.error("❌ API key error - please verify your Gemini API key is valid");
+        console.error("API key error - please verify your Gemini API key is valid");
         reply = "I'm having trouble connecting to my knowledge base. Please check if the **API key** is properly configured. In the meantime, I can still help with **general fitness advice**!";
         usedFallback = true;
       } else {
@@ -219,13 +218,6 @@ router.post("/", chatLimiter, async (req, res) => {
     }
 
     res.json({ reply });
-  } catch (err) {
-    console.error("Chat route error:", err);
-    res.status(500).json({
-      error: "Failed to generate response",
-      details: process.env.NODE_ENV === "development" ? err.message : undefined,
-    });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -41,7 +41,6 @@ function calculateInactivityInfo(lastOrderDate) {
 // Admin-only access to protect customer PII
 // ─────────────────────────────────────────────────────────────────────────────
 router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
     console.log('[API] GET /customers request received');
 
     const customers = await Order.aggregate([
@@ -113,11 +112,7 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
 
     console.log(`[API] Returning ${result.length} enriched customers`);
     res.json({ success: true, data: result });
-  } catch (err) {
-    console.error('[API] GET /customers error:', err);
-    res.status(500).json({ success: false, error: err.message || 'Server error' });
-  }
-});
+  });
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GET /api/customers/:userId
@@ -125,7 +120,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
 // Admin-only access to protect customer PII
 // ─────────────────────────────────────────────────────────────────────────────
 router.get('/:userId', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
     const { userId } = req.params;
 
     const orders = await Order.find({ userId, status: 'paid' })
@@ -173,11 +167,7 @@ router.get('/:userId', verifyFirebaseToken, verifyAdmin, async (req, res) => {
         orders,
       },
     });
-  } catch (err) {
-    console.error('Customer detail error:', err);
-    res.status(500).json({ success: false, error: err.message || 'Server error' });
-  }
-});
+  });
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/customers/:userId/send-reminder
@@ -185,7 +175,6 @@ router.get('/:userId', verifyFirebaseToken, verifyAdmin, async (req, res) => {
 // Admin-only endpoint: requires Firebase auth token from admin user
 // ─────────────────────────────────────────────────────────────────────────────
 router.post('/:userId/send-reminder', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
     const { userId } = req.params;
 
     // Send the reminder email
@@ -196,10 +185,6 @@ router.post('/:userId/send-reminder', verifyFirebaseToken, verifyAdmin, async (r
     }
 
     res.json({ success: true, message: result.message });
-  } catch (err) {
-    console.error('send-reminder error:', err);
-    res.status(500).json({ success: false, error: err.message });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -29,7 +29,6 @@ const getStartDate = (range) => {
 // GET /api/dashboard?range=today|week|month
 // Admin-only dashboard metrics
 router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
     const range = req.query.range || 'month';
     const startDate = getStartDate(range);
 
@@ -140,11 +139,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
       topProducts,
       recentOrders,   // each order now has customerName + customerEmail
     });
-
-  } catch (err) {
-    console.error('Dashboard route error:', err);
-    res.status(500).json({ success: false, message: 'Failed to load dashboard data' });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/exercises.js
+++ b/server/routes/exercises.js
@@ -123,7 +123,6 @@ router.get("/:category", async (req, res) => {
     });
   }
 
-  try {
     const bodyParts = CATEGORY_MAPPING[category.toLowerCase()];
     const allExercises = [];
 
@@ -134,7 +133,7 @@ router.get("/:category", async (req, res) => {
         allExercises.push(...exercises);
       } catch (error) {
         console.warn(
-          `⚠️ Failed to fetch exercises for bodyPart "${bodyPart}": ${error.message}`
+          `Failed to fetch exercises for bodyPart "${bodyPart}": ${error.message}`
         );
         // Continue with other body parts even if one fails
       }
@@ -160,29 +159,23 @@ router.get("/:category", async (req, res) => {
       console.log("  Name:", firstEx.name);
       
       if (firstEx.gifUrl) {
-        console.log("  gifUrl: ✅ Present");
+        console.log("  gifUrl: Present");
         console.log("    Value:", firstEx.gifUrl.substring(0, 80) + (firstEx.gifUrl.length > 80 ? "..." : ""));
-        console.log("    Starts with http:", firstEx.gifUrl.startsWith("http") ? "✅ Yes" : "❌ No");
+        console.log("    Starts with http:", firstEx.gifUrl.startsWith("http") ? "Yes" : "No");
       } else {
-        console.log("  gifUrl: ❌ null/empty");
+        console.log("  gifUrl: null/empty");
         console.log("    imageUrl fallback:", firstEx.imageUrl ? `Present: ${firstEx.imageUrl.substring(0, 60)}...` : "null");
       }
       
-      console.log("  imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-      console.log("  videoUrl:", firstEx.videoUrl ? `✅ Present` : "❌ null");
+      console.log("  imageUrl:", firstEx.imageUrl ? "Present" : "null");
+      console.log("  videoUrl:", firstEx.videoUrl ? "Present" : "null");
       console.log("");
     }
 
     console.log(
-      `✅ Fetched ${deduplicatedExercises.length} unique exercises for category "${category}"`
+      `Fetched ${deduplicatedExercises.length} unique exercises for category "${category}"`
     );
     res.json(deduplicatedExercises);
-  } catch (error) {
-    console.error(`❌ Error fetching exercises for category "${category}":`, error);
-    res.status(500).json({
-      error: "Failed to fetch exercises. Please try again later.",
-    });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/fitnessCenters.js
+++ b/server/routes/fitnessCenters.js
@@ -46,7 +46,6 @@ function computeDistanceScore(userAddr, center) {
 
 // GET /api/fitness-centers/nearby?type=gym
 router.get("/nearby", verifyFirebaseToken, async (req, res) => {
-  try {
     const uid = req.user?.uid;
     if (!uid) return res.status(401).json({ error: "Unauthorized" });
 
@@ -76,10 +75,6 @@ router.get("/nearby", verifyFirebaseToken, async (req, res) => {
 
     const top = scored.slice(0, 10);
     return res.json(top);
-  } catch (err) {
-    console.error("/api/fitness-centers/nearby error:", err);
-    return res.status(500).json({ error: "Server error" });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -43,7 +43,6 @@ async function releaseAndClearCart(userId) {
  * @access  Private
  */
 router.post("/create-order", verifyFirebaseToken, async (req, res) => {
-  try {
     const { amount, currency = "INR", userId } = req.body;
     if (!amount || !userId)
       return res.status(400).json({ error: "amount and userId are required" });
@@ -60,11 +59,7 @@ router.post("/create-order", verifyFirebaseToken, async (req, res) => {
     });
 
     res.json(order);
-  } catch (err) {
-    console.error("Razorpay create-order error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 /**
  * @route   POST /verify-payment
@@ -74,7 +69,6 @@ router.post("/create-order", verifyFirebaseToken, async (req, res) => {
  * @access  Private
  */
 router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
-  try {
     const { razorpay_order_id, razorpay_payment_id, razorpay_signature, userId } = req.body;
 
     if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature)
@@ -165,12 +159,7 @@ router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
     });
 
     res.json({ success: true, order });
-
-  } catch (err) {
-    console.error("verify-payment error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 /**
  * @route   POST /clear-cart
@@ -179,17 +168,12 @@ router.post("/verify-payment", verifyFirebaseToken, async (req, res) => {
  * @access  Private
  */
 router.post("/clear-cart", verifyFirebaseToken, async (req, res) => {
-  try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId is required" });
 
     await releaseAndClearCart(userId);
     res.json({ success: true });
-  } catch (err) {
-    console.error("clear-cart error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /demo-success   ← DEV / TEST ONLY — disabled in production
@@ -205,7 +189,6 @@ router.post("/clear-cart", verifyFirebaseToken, async (req, res) => {
  * @access  Public (TESTING ONLY) - No authentication required
  */
 router.post("/demo-success", async (req, res) => {
-  try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId is required" });
 
@@ -242,11 +225,7 @@ router.post("/demo-success", async (req, res) => {
     });
 
     res.json({ success: true, paymentId: fakePaymentId, order });
-  } catch (err) {
-    console.error("demo-success error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 module.exports = router;

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -19,7 +19,6 @@ const { createProductSchema, updateProductSchema } = require('../validation/requ
  * @access  Public
  */
 router.get('/', async (req, res) => {
-  try {
     // Query parameters
     const all = req.query.all === 'true';
     const page = parseInt(req.query.page) || 1;
@@ -105,11 +104,7 @@ router.get('/', async (req, res) => {
     if (ifNoneMatch && ifNoneMatch === etag) return res.status(304).end();
 
     return res.json(payload);
-  } catch (err) {
-    console.error('[products] GET /api/products error:', err);
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   GET /api/products/low-stock
@@ -118,15 +113,11 @@ router.get('/', async (req, res) => {
  */
 
 router.get('/low-stock', async (req, res) => {
-  try {
     // only check products where stock is not null
     const products = await Product.find({ stock: { $ne: null } });
     const lowStock = products.filter(p => (p.stock - p.reserved) < LOW_STOCK_THRESHOLD);
     res.json(lowStock);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   GET /api/products/:id
@@ -141,14 +132,10 @@ router.get('/:id', async (req, res) => {
     return res.status(400).json({ error: 'Invalid product ID. It must be a number.' });
   }
 
-  try {
     const product = await Product.findOne({ productId });
     if (!product) return res.status(404).json({ error: 'Product not found' });
     res.json(product);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   POST /api/products
@@ -156,7 +143,6 @@ router.get('/:id', async (req, res) => {
  * @access  Private (Admin)
  */
 router.post('/', verifyFirebaseToken, verifyAdmin, validateRequest(createProductSchema), async (req, res) => {
-  try {
     const body = req.body;
     const existing = await Product.findOne({ productId: body.productId });
     if (existing) return res.status(400).json({ error: 'productId already exists' });
@@ -165,10 +151,7 @@ router.post('/', verifyFirebaseToken, verifyAdmin, validateRequest(createProduct
     // invalidate product caches
     try { await cache.delPattern('products:'); } catch (e) { }
     res.status(201).json(p);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   PUT /api/products/:id
@@ -182,15 +165,11 @@ router.put('/:id', verifyFirebaseToken, verifyAdmin, validateRequest(updateProdu
     return res.status(400).json({ error: 'Invalid product ID. It must be a number.' });
   }
 
-  try {
     const updated = await Product.findOneAndUpdate({ productId }, req.body, { new: true });
     if (!updated) return res.status(404).json({ error: 'Product not found' });
     try { await cache.delPattern('products:'); } catch (e) { }
     res.json(updated);
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 /**
  * @route   DELETE /api/products/:id
@@ -204,13 +183,9 @@ router.delete('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   if (isNaN(productId)) {
     return res.status(400).json({ error: 'Invalid product ID. It must be a number.' });
   }
-  try {
     const deleted = await Product.findOneAndDelete({ productId });
     try { await cache.delPattern('products:'); } catch (e) { }
     res.json({ success: true });
-  } catch (err) {
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -12,7 +12,6 @@ const verifyAdmin = require('../middleware/verifyAdmin');
  * @access  Public
  */
 router.get('/sales', verifyFirebaseToken, verifyAdmin, async (req, res) => {
-  try {
     const { range = 'weekly' } = req.query;
 
     // Step 1: Calculate the start date based on range
@@ -113,10 +112,6 @@ router.get('/sales', verifyFirebaseToken, verifyAdmin, async (req, res) => {
       revenueByDate,
       productPerformance,
     });
-  } catch (err) {
-    console.error('Reports error:', err);
-    res.status(500).json({ error: 'Server error' });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/rewards.js
+++ b/server/routes/rewards.js
@@ -34,7 +34,6 @@ function calculatePoints(source, amount = 0) {
 }
 
 router.get("/:userId", verifyFirebaseToken, async (req, res) => {
-  try {
     const { userId } = req.params;
 
     let rewards = await Rewards.findOne({ userId });
@@ -57,14 +56,9 @@ router.get("/:userId", verifyFirebaseToken, async (req, res) => {
       tier: getTier(rewards.pointsBalance),
       transactions,
     });
-  } catch (error) {
-    console.error("Get rewards error:", error);
-    return res.status(500).json({ message: "Failed to fetch rewards" });
-  }
-});
+  });
 
 router.post("/earn", verifyFirebaseToken, async (req, res) => {
-  try {
     const { userId, source, orderId, amount, description } = req.body;
 
     if (!userId || !source) {
@@ -131,10 +125,6 @@ router.post("/earn", verifyFirebaseToken, async (req, res) => {
       tier: getTier(rewards.pointsBalance),
       transaction,
     });
-  } catch (error) {
-    console.error("Earn rewards error:", error);
-    return res.status(500).json({ message: "Failed to earn rewards" });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -29,7 +29,6 @@ const upload = multer({
 // Also syncs user email from Firebase to the profile for email sending.
 // ─────────────────────────────────────────────────────────────────────────────
 router.post("/login", async (req, res) => {
-  try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
@@ -85,11 +84,7 @@ router.post("/login", async (req, res) => {
       discountUsed: profile.discountUsed,
       discountPercent: profile.discountPercent,
     });
-  } catch (err) {
-    console.error("user/login error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -99,7 +94,6 @@ router.post("/login", async (req, res) => {
 // Flips isFirstLogin → false so it never shows again.
 // ─────────────────────────────────────────────────────────────────────────────
 router.post("/dismiss-banner", async (req, res) => {
-  try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
@@ -109,11 +103,7 @@ router.post("/dismiss-banner", async (req, res) => {
       { upsert: true }
     );
     res.json({ success: true });
-  } catch (err) {
-    console.error("user/dismiss-banner error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -123,7 +113,6 @@ router.post("/dismiss-banner", async (req, res) => {
 // Flips discountUsed → true so it can't be used again.
 // ─────────────────────────────────────────────────────────────────────────────
 router.post("/use-discount", async (req, res) => {
-  try {
     const { userId } = req.body;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
@@ -138,11 +127,7 @@ router.post("/use-discount", async (req, res) => {
     }
 
     res.json({ success: true });
-  } catch (err) {
-    console.error("user/use-discount error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -151,7 +136,6 @@ router.post("/use-discount", async (req, res) => {
 // Used by Checkout to decide whether to apply the 10% discount.
 // ─────────────────────────────────────────────────────────────────────────────
 router.get("/discount-status/:userId", async (req, res) => {
-  try {
     const { userId } = req.params;
     const profile = await UserProfile.findOne({ userId });
 
@@ -164,11 +148,7 @@ router.get("/discount-status/:userId", async (req, res) => {
       discountUsed: profile.discountUsed,
       discountPercent: profile.discountPercent,
     });
-  } catch (err) {
-    console.error("user/discount-status error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -176,18 +156,13 @@ router.get("/discount-status/:userId", async (req, res) => {
 // Returns stored profile (including addresses) for a user
 // ─────────────────────────────────────────────────────────────────────────────
 router.get("/profile/:userId", async (req, res) => {
-  try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
     const profile = await UserProfile.findOne({ userId });
     if (!profile) return res.json({});
     res.json(profile);
-  } catch (err) {
-    console.error("user/profile GET error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -196,7 +171,6 @@ router.get("/profile/:userId", async (req, res) => {
 // Creates profile if missing.
 // ─────────────────────────────────────────────────────────────────────────────
 router.put("/profile/:userId", async (req, res) => {
-  try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
@@ -218,11 +192,7 @@ router.put("/profile/:userId", async (req, res) => {
     );
 
     res.json(profile);
-  } catch (err) {
-    console.error("user/profile PUT error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/user/upload-photo/:userId
@@ -230,7 +200,6 @@ router.put("/profile/:userId", async (req, res) => {
 // Body: multipart form-data with 'photo' field
 // ─────────────────────────────────────────────────────────────────────────────
 router.post("/upload-photo/:userId", verifyFirebaseToken, upload.single("photo"), async (req, res) => {
-  try {
     const { userId } = req.params;
     if (!userId) return res.status(400).json({ error: "userId required" });
 
@@ -269,10 +238,6 @@ router.post("/upload-photo/:userId", verifyFirebaseToken, upload.single("photo")
       console.error("Cloudinary upload failed:", uploadErr);
       return res.status(500).json({ error: "Failed to upload photo" });
     }
-  } catch (err) {
-    console.error("user/upload-photo error:", err);
-    res.status(500).json({ error: err.message });
-  }
-});
+  });
 
 module.exports = router;

--- a/server/routes/workouts.js
+++ b/server/routes/workouts.js
@@ -11,7 +11,6 @@ const { updateWorkoutLogSchema } = require('../validation/requestSchemas');
  * @access  Private
  */
 router.get('/', verifyFirebaseToken, async (req, res) => {
-  try {
     const logs = await WorkoutLog.find({ userId: req.user.uid });
     
     // Format response to match the legacy localStorage format: { 'YYYY-MM-DD': { title, notes, exercises } }
@@ -25,11 +24,7 @@ router.get('/', verifyFirebaseToken, async (req, res) => {
     }
     
     res.json(formattedLogs);
-  } catch (err) {
-    console.error('Error fetching workout logs:', err);
-    res.status(500).json({ error: 'Server error fetching workout logs' });
-  }
-});
+  });
 
 /**
  * @route   POST /api/workouts
@@ -37,7 +32,6 @@ router.get('/', verifyFirebaseToken, async (req, res) => {
  * @access  Private
  */
 router.post('/', verifyFirebaseToken, validateRequest(updateWorkoutLogSchema), async (req, res) => {
-  try {
     const { date, title, notes, exercises } = req.body;
 
     const logData = {
@@ -53,11 +47,7 @@ router.post('/', verifyFirebaseToken, validateRequest(updateWorkoutLogSchema), a
     );
 
     res.json(updatedLog);
-  } catch (err) {
-    console.error('Error saving workout log:', err);
-    res.status(500).json({ error: 'Server error saving workout log' });
-  }
-});
+  });
 
 /**
  * @route   DELETE /api/workouts/:date
@@ -65,14 +55,9 @@ router.post('/', verifyFirebaseToken, validateRequest(updateWorkoutLogSchema), a
  * @access  Private
  */
 router.delete('/:date', verifyFirebaseToken, async (req, res) => {
-  try {
     const { date } = req.params;
     await WorkoutLog.findOneAndDelete({ userId: req.user.uid, date });
     res.json({ success: true });
-  } catch (err) {
-    console.error('Error deleting workout log:', err);
-    res.status(500).json({ error: 'Server error deleting workout log' });
-  }
-});
+  });
 
 module.exports = router;


### PR DESCRIPTION
Closes #556

## Summary

Removes redundant try/catch wrappers from 37 async route handlers across 13 server route files. Express 5 natively catches async rejections and forwards them to the global error handler, making boilerplate catch blocks that just return generic 500 responses unnecessary.

## Files modified

- `server/routes/products.js` (6 handlers)
- `server/routes/user.js` (7 handlers)
- `server/routes/cart.js` (4 handlers)
- `server/routes/payment.js` (4 handlers)
- `server/routes/rewards.js` (2 handlers)
- `server/routes/bugs.js` (3 handlers)
- `server/routes/customers.js` (3 handlers)
- `server/routes/dashboard.js` (1 handler)
- `server/routes/reports.js` (1 handler)
- `server/routes/chat.js` (1 handler)
- `server/routes/exercises.js` (1 handler)
- `server/routes/workouts.js` (3 handlers)
- `server/routes/fitnessCenters.js` (1 handler)

## Not modified (kept intentional)

- `server/routes/orders.js` - POST / has custom error mapping (400 vs 500 based on error type)
- `server/routes/github.js` - catch block has custom fallback/cache logic

## Testing

- All 66 existing tests pass
- All route modules load without errors