### PR TITLE
fix: add missing FitnessCenter schema fields

### DIFF
--- a/server/models/FitnessCenter.js
+++ b/server/models/FitnessCenter.js
@@ -2,17 +2,71 @@ const mongoose = require("mongoose");
 
 const fitnessCenterSchema = new mongoose.Schema(
   {
+    // Existing fields
     name: { type: String, required: true },
-    type: { type: String, enum: ["gym", "yoga", "pilates", "fitness_studio"], required: true },
-    address: { type: String },
-    city: { type: String },
-    state: { type: String },
-    lat: { type: Number },
-    lng: { type: Number },
+    type: {
+      type: String,
+      enum: ["gym", "yoga", "pilates", "fitness_studio"],
+      required: true,
+    },
+    address: String,
+    city: String,
+    state: String,
+    lat: Number,
+    lng: Number,
     rating: { type: Number, min: 0, max: 5, default: 4.0 },
-    imageUrl: { type: String },
-    contact: { type: String },
+    imageUrl: String,
+    contact: String,
     isOpen: { type: Boolean, default: true },
+
+    // New fields
+    postalCode: String,
+    country: String,
+    totalReviews: Number,
+
+    ratingBreakdown: {
+      "5star": Number,
+      "4star": Number,
+      "3star": Number,
+      "2star": Number,
+      "1star": Number,
+    },
+
+    gallery: [String],
+
+    alternateContact: String,
+    email: String,
+    website: String,
+
+    openingHours: {
+      monday: String,
+      tuesday: String,
+      wednesday: String,
+      thursday: String,
+      friday: String,
+      saturday: String,
+      sunday: String,
+    },
+
+    amenities: [String],
+
+    membershipPlans: [
+      {
+        plan: String,
+        price: Number,
+        currency: String,
+      },
+    ],
+
+    trainers: Number,
+    capacity: Number,
+    established: Number,
+
+    description: String,
+
+    specialties: [String],
+
+    paymentMethods: [String],
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## 📋 What does this PR do?

* Added missing fields to the `FitnessCenter` Mongoose schema.
* Aligned the schema with the data structure used in `seedFitnessCenters.js`.
* Prevented Mongoose strict mode from silently dropping seeded fitness center data.

## 🔗 Related Issue

Closes #359

## 🧪 How was this tested?

* Verified the schema syntax using:

  ```bash
  node -c server/models/FitnessCenter.js
  ```

* Confirmed all fields present in the seed data are now represented in the schema.

## 📸 Screenshots (if UI changes)

N/A – No UI changes.

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys
