### PR TITLE
fix: increase body parser limit to 1mb

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -106,8 +106,8 @@ app.use(
 );
 
 app.use(helmet());
-app.use(express.json({ limit: "10kb" }));
-app.use(express.urlencoded({ extended: true, limit: "10kb" }));
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
 app.disable("etag");
 


### PR DESCRIPTION
## What does this PR do?

This PR addresses Issue #360 by increasing the global request body size limit from 10KB to 1MB.

### Changes made
- Updated `express.json()` limit from `10kb` to `1mb`
- Updated `express.urlencoded()` limit from `10kb` to `1mb`

### Related Issue
Closes #360

### How was this tested?
- Verified the application builds successfully after the change.
- Confirmed only the body parser limits were modified.

### Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys