### PR TITLE
refactor: centralize low stock threshold configuration

### DIFF
--- a/client/src/config/constants.js
+++ b/client/src/config/constants.js
@@ -1,0 +1,6 @@
+// src/config/constants.js
+
+// Stock Thresholds
+// Products with available stock below this value are considered "low stock".
+// Keep this in sync with server/config/constants.js (LOW_STOCK_THRESHOLD).
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -3,8 +3,8 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { LOW_STOCK_THRESHOLD } from "../config/constants";
 
-const LOW_STOCK_THRESHOLD = 5;
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -7,6 +7,7 @@ const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
+const { LOW_STOCK_THRESHOLD } = require('../config/constants');
 
 // ── Helper: get the start date based on the time range filter
 // 'today'  -> start of today
@@ -50,7 +51,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -113,7 +113,7 @@ router.get('/', async (req, res) => {
 
 /**
  * @route   GET /api/products/low-stock
- * @desc    Returns all products where available stock (stock - reserved) is below threshold of 5
+ * @desc    Returns all products where available stock (stock - reserved) is below the shared LOW_STOCK_THRESHOLD
  * @access  Public
  */
 


### PR DESCRIPTION
## Summary

This PR centralizes the low-stock threshold configuration by replacing hardcoded values with a shared constant.

### Changes Made

* Replaced the hardcoded low-stock threshold in `server/routes/dashboard.js`
* Added `client/src/config/constants.js` to provide a shared client-side threshold constant
* Updated `AdminInventory.jsx` to use the shared constant
* Updated the stale documentation comment in `server/routes/products.js`

### Result

All low-stock calculations now use a consistent threshold value across the application, eliminating duplicated business logic and preventing future inconsistencies.

Closes #242
