### PR TITLE
fix: increase request body limit from 10kb to 1mb

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -106,8 +106,8 @@ app.use(
 );
 
 app.use(helmet());
-app.use(express.json({ limit: "10kb" }));
-app.use(express.urlencoded({ extended: true, limit: "10kb" }));
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
 app.disable("etag");
 


### PR DESCRIPTION
## Summary

This PR increases the global request body size limit from `10kb` to `1mb` for both JSON and URL-encoded payloads.

### Changes

* Updated `express.json()` limit from `10kb` to `1mb`
* Updated `express.urlencoded()` limit from `10kb` to `1mb`

### Why

The current `10kb` limit may reject legitimate requests such as:

* Profile updates with multiple addresses
* Detailed bug reports
* Larger order payloads
* Future bulk operations

The repository already includes custom handling for oversized payloads (`413 Payload Too Large`), so this change focuses on increasing the allowed request size while preserving existing error handling.

Closes #360
