### PR TITLE
 Add minimum validation to stock field in Product schema

### DIFF
--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -13,7 +13,11 @@ const ProductSchema = new mongoose.Schema(
     badge: { type: String, default: null },
     image: { type: String, default: '' },
     // total stock available (optional). If null, stock is not enforced.
-    stock: { type: Number, default: null },
+    stock: {
+      type: Number,
+      default: null,
+      min: [0, 'stock cannot be negative'],
+    },
     // quantity reserved by carts (sum of quantities currently in carts)
     reserved: {
       type: Number,


### PR DESCRIPTION
## Changes
- Added `min: [0, 'stock cannot be negative']` validation to the `stock` field in `server/models/Product.js`.

## Why
- Prevents negative stock values from being persisted at the schema level.
- Preserves existing behavior where `stock: null` means stock is not enforced.

## Impact
- `stock = null` ✅ Allowed
- `stock >= 0` ✅ Allowed
- `stock < 0` ❌ Rejected by Mongoose validation