### PR TITLE
refactor: centralize low stock threshold configuration

### DIFF
--- a/client/src/constants/inventory.js
+++ b/client/src/constants/inventory.js
@@ -1,0 +1,1 @@
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -3,8 +3,8 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { LOW_STOCK_THRESHOLD } from "../constants/inventory";
 
-const LOW_STOCK_THRESHOLD = 5;
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -82,3 +82,4 @@ SMTP_PASS=your_smtp_password
 
 SMTP_FROM=noreply@fitmart.com
 ```
+LOW_STOCK_THRESHOLD=5

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -2,7 +2,8 @@
 
 const CONSTANTS = {
   // Stock Thresholds
-  LOW_STOCK_THRESHOLD: 5,
+  LOW_STOCK_THRESHOLD:
+    parseInt(process.env.LOW_STOCK_THRESHOLD, 10) || 5,
 
   // Server Config
   DEFAULT_PORT: 5000,

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -8,6 +8,8 @@ const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
 
+const { LOW_STOCK_THRESHOLD } = require("../config/constants");
+
 // ── Helper: get the start date based on the time range filter
 // 'today'  -> start of today
 // 'week'   -> last 7 days (including today)
@@ -50,7 +52,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });


### PR DESCRIPTION
## 📄 What does this PR do?

This PR centralizes the low-stock threshold configuration across both the backend and frontend to eliminate inconsistencies caused by hardcoded values.

### Changes Made

#### Backend

* Replaced the hardcoded `LOW_STOCK_THRESHOLD = 10` in `server/routes/dashboard.js` with the shared constant from `server/config/constants.js`.
* Updated `server/config/constants.js` to read `LOW_STOCK_THRESHOLD` from `process.env` with a fallback value of `5`.
* Added `LOW_STOCK_THRESHOLD=5` to `server/.env.example`.

#### Frontend

* Created `client/src/constants/inventory.js` to store the low-stock threshold in a single location.
* Updated `client/src/pages/AdminInventory.jsx` to import and use the shared constant instead of a hardcoded value.

## 🔗 Related Issue

Closes #242

## 🧪 How was this tested?

* Verified that the dashboard route uses the shared threshold value instead of a hardcoded value.
* Verified that the inventory page uses the centralized frontend constant.
* Confirmed that all hardcoded threshold definitions were removed from the affected files.
* Confirmed that the threshold can now be configured through environment variables with a fallback value.

## 📸 Screenshots

N/A (No UI changes)

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys