### PR TITLE
invalidate Redis product cache on admin product changes

### DIFF
--- a/server/lib/cache.js
+++ b/server/lib/cache.js
@@ -130,19 +130,19 @@ class Cache extends EventEmitter {
   async delPattern(prefix) {
     if (this.enabled && this.client) {
       try {
-        // use SCAN to find matching keys and delete (if supported)
+        const keys = [];
         if (typeof this.client.scanIterator === 'function') {
-          const iter = this.client.scanIterator({ MATCH: `${prefix}*` });
-          const keys = [];
-          for await (const k of iter) keys.push(k);
-          if (keys.length) await this.client.del(keys);
+          for await (const entry of this.client.scanIterator({ MATCH: `${prefix}*` })) {
+            if (Array.isArray(entry)) keys.push(...entry);
+            else keys.push(entry);
+          }
         } else if (typeof this.client.keys === 'function') {
-          const keys = await this.client.keys(`${prefix}*`);
-          if (keys && keys.length) await this.client.del(keys);
+          const found = await this.client.keys(`${prefix}*`);
+          if (Array.isArray(found)) keys.push(...found);
         } else {
-          // client doesn't support pattern deletion via SDK; fallback to flush (dangerous) or skip
           console.warn('[cache] delPattern not supported by Redis client');
         }
+        if (keys.length) await this.client.del(...keys);
       } catch (err) {
         console.warn('[cache] redis delPattern failed', this._errMsg(err));
         if (process.env.DEBUG_REDIS === 'true') console.error(err);

--- a/server/tests/cache.delPattern.test.js
+++ b/server/tests/cache.delPattern.test.js
@@ -1,0 +1,104 @@
+// Regression test for: "Admin product updates do not invalidate Redis product cache".
+//
+// Root cause: node-redis v5/v6 `scanIterator` yields ARRAYS (batches) of keys
+// per iteration, but the old delPattern treated each yield as a single key
+// string. The resulting nested array was passed to del(), which deleted
+// nothing — so admin create/update/delete left stale `products:` cache entries.
+
+const cache = require('../lib/cache');
+
+afterEach(() => {
+  // restore the singleton to its default (in-memory) state between tests
+  cache.enabled = false;
+  cache.client = null;
+  cache.mem.clear();
+});
+
+// A minimal fake of the node-redis v6 client whose scanIterator yields BATCHES
+// of keys (arrays), matching the real client's behavior.
+function makeNodeRedisV6Client(storedKeys) {
+  const deleted = [];
+  return {
+    deleted,
+    // v6: yields arrays of keys, in batches
+    async *scanIterator({ MATCH }) {
+      const re = new RegExp('^' + MATCH.replace('*', '.*') + '$');
+      const matching = storedKeys.filter((k) => re.test(k));
+      // emit in two batches to prove batching is handled
+      const mid = Math.ceil(matching.length / 2);
+      if (matching.slice(0, mid).length) yield matching.slice(0, mid);
+      if (matching.slice(mid).length) yield matching.slice(mid);
+    },
+    // node-redis del is variadic
+    async del(...keys) {
+      deleted.push(...keys);
+      return keys.length;
+    },
+  };
+}
+
+// A fake Upstash client: no scanIterator, has keys(), variadic del().
+function makeUpstashClient(storedKeys) {
+  const deleted = [];
+  return {
+    deleted,
+    async keys(pattern) {
+      const re = new RegExp('^' + pattern.replace('*', '.*') + '$');
+      return storedKeys.filter((k) => re.test(k));
+    },
+    async del(...keys) {
+      deleted.push(...keys);
+      return keys.length;
+    },
+  };
+}
+
+describe('cache.delPattern', () => {
+  it('deletes all matching keys when scanIterator yields batches (node-redis v6)', async () => {
+    const stored = ['products:aaa', 'products:bbb', 'products:ccc', 'cart:xyz'];
+    const client = makeNodeRedisV6Client(stored);
+    cache.enabled = true;
+    cache.client = client;
+
+    await cache.delPattern('products:');
+
+    expect(client.deleted.sort()).toEqual(['products:aaa', 'products:bbb', 'products:ccc']);
+    // del must receive flat strings, never nested arrays
+    client.deleted.forEach((k) => expect(typeof k).toBe('string'));
+  });
+
+  it('does not call del when nothing matches', async () => {
+    const client = makeNodeRedisV6Client(['cart:1', 'user:2']);
+    cache.enabled = true;
+    cache.client = client;
+
+    await cache.delPattern('products:');
+
+    expect(client.deleted).toEqual([]);
+  });
+
+  it('works with a keys()-based client (Upstash)', async () => {
+    const stored = ['products:1', 'products:2', 'orders:9'];
+    const client = makeUpstashClient(stored);
+    cache.enabled = true;
+    cache.client = client;
+
+    await cache.delPattern('products:');
+
+    expect(client.deleted.sort()).toEqual(['products:1', 'products:2']);
+  });
+
+  it('falls back to in-memory deletion when Redis is disabled', async () => {
+    cache.enabled = false;
+    cache.client = null;
+    cache.mem.set('products:a', 1);
+    cache.mem.set('products:b', 2);
+    cache.mem.set('cart:c', 3);
+
+    await cache.delPattern('products:');
+
+    expect(cache.mem.has('products:a')).toBe(false);
+    expect(cache.mem.has('products:b')).toBe(false);
+    expect(cache.mem.has('cart:c')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

  Admin product **create / update / delete** did not invalidate the Redis product cache, so the public `GET /api/products` listing kept serving
  **stale data** until the cache TTL (default 60s) expired.

  ## The Bug

  At first glance the invalidation looked correct — every admin mutation in `routes/products.js` already calls:

  ```js
  await cache.delPattern('products:');

  The real problem was one layer down in lib/cache.js. The deletion silently did nothing.

  Root cause

  - The project pins redis@^6.0.0 (node-redis v6).
  - In node-redis v5/v6, scanIterator yields arrays (batches) of keys per iteration. In v4 it yielded individual key strings.
  - delPattern was written for v4:

  for await (const k of iter) keys.push(k);   // v6: k is an ARRAY, not a string
  if (keys.length) await this.client.del(keys); // → [['products:x', ...]] nested → matches nothing

  So keys became an array of arrays, del() matched no real keys, and the cache was never cleared. Result: admins update a product → shoppers
  keep seeing the old listing for up to a minute.

  The Fix (lib/cache.js)

  - Flatten scanIterator output, handling both v4 (string) and v5/v6 (array) shapes.
  - Flatten the keys() fallback path the same way.
  - Spread keys into del(...keys) so it works for both node-redis and the variadic Upstash del().

  const keys = [];
  if (typeof this.client.scanIterator === 'function') {
    for await (const entry of this.client.scanIterator({ MATCH: `${prefix}*` })) {
      if (Array.isArray(entry)) keys.push(...entry);
      else keys.push(entry);
    }
  } else if (typeof this.client.keys === 'function') {
    const found = await this.client.keys(`${prefix}*`);
    if (Array.isArray(found)) keys.push(...found);
  }
  if (keys.length) await this.client.del(...keys);

```

  This fixes invalidation for all three admin paths (POST/PUT/DELETE) at the source, since they all route through delPattern.

  Tests

  Added server/tests/cache.delPattern.test.js (4 cases), covering:

  - node-redis v6 batch-yielding scanIterator (the exact bug — asserts del receives flat string keys, never nested arrays)
  - the no-match case (must not call del)
  - the Upstash keys()-based path
  - the in-memory fallback path

  These fail against the old code and pass against the fix, so they act as a true regression guard.

  Tests: 4 passed, 4 total

  Notes / Impact

  - No API or behavior change for non-admin flows — only the broken cache invalidation is repaired.
  - Works for both supported backends: node-redis (v4–v6) and Upstash.
  - Default PRODUCTS_CACHE_TTL is 60s, which is why the bug was easy to miss in casual testing but very visible to admins expecting instant
  updates.