### PR TITLE
fix: add product stock min validation

### DIFF
--- a/server/models/Product.js
+++ b/server/models/Product.js
@@ -13,7 +13,11 @@ const ProductSchema = new mongoose.Schema(
     badge: { type: String, default: null },
     image: { type: String, default: '' },
     // total stock available (optional). If null, stock is not enforced.
-    stock: { type: Number, default: null },
+    stock: {
+      type: Number,
+      default: null,
+      min: [0, 'stock cannot be negative'],
+    },
     // quantity reserved by carts (sum of quantities currently in carts)
     reserved: {
       type: Number,


### PR DESCRIPTION
## Summary
- add Mongoose schema-level min validation for Product stock
- keep Product stock default as null
- keep existing reserved min validation from upstream unchanged

Related to #354

## Validation
- Product schema validation probe for negative stock/reserved: passed
- npm test -- tests/products.test.js tests/requestSchemas.test.js: passed (66 tests)
- npm test: blocked by upstream cart test hardcoding a Windows MongoDB binary path (C:\Program Files\MongoDB\Server\8.0\bin\mongod.exe) in this environment
- npm audit --audit-level=high: reports existing dependency advisories (28 total, 2 high)