### PR TITLE
Remove debug logs from ExercisePage

### DIFF
--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -59,20 +59,6 @@ export default function ExercisePage() {
       }
 
       const data = await response.json();
-
-      // Client-side debug logging
-      if (data && data.length > 0) {
-        const firstEx = data[0];
-        console.log(`\n[Exercise Client] Received ${data.length} exercises for "${bodyPart}"`);
-        console.log("  First exercise name:", firstEx.name);
-        console.log("  First exercise gifUrl:", firstEx.gifUrl ? `✅ Present` : "❌ null");
-        console.log("  First exercise imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-        if (firstEx.gifUrl) {
-          console.log("  GIF URL preview:", firstEx.gifUrl.substring(0, 100));
-        }
-        console.log("");
-      }
-
       setExercises(data || []);
     } catch (err) {
       setError(err.message || "Failed to load exercises. Please try again.");


### PR DESCRIPTION
Closes #579

## Summary
- Removed leftover debug console.log statements from fetchExercises in ExercisePage
- Kept fetch logic and error handling unchanged

## Testing
- Ran npm run build