### PR TITLE
fix(chat): include conversation history in Gemini prompt

### DIFF
--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -6,7 +6,12 @@ const Product = require("../models/Product");
 
 const { z } = require("zod");
 
-const { PRODUCT_KEYWORDS, SYSTEM_PROMPT, getFallbackResponse, PRODUCT_TEMPLATE } = require("../config/chatConfig");
+const {
+  PRODUCT_KEYWORDS,
+  SYSTEM_PROMPT,
+  getFallbackResponse,
+  PRODUCT_TEMPLATE,
+} = require("../config/chatConfig");
 
 const router = express.Router();
 
@@ -21,11 +26,18 @@ const chatLimiter = rateLimit({
 });
 
 console.log("API Key exists:", !!process.env.GEMINI_API_KEY);
-console.log("API Key prefix:", process.env.GEMINI_API_KEY ? process.env.GEMINI_API_KEY.substring(0, 15) + "..." : "MISSING");
+console.log(
+  "API Key prefix:",
+  process.env.GEMINI_API_KEY
+    ? process.env.GEMINI_API_KEY.substring(0, 15) + "..."
+    : "MISSING",
+);
 
 if (!process.env.GEMINI_API_KEY) {
   console.error("❌ GEMINI_API_KEY is not set in environment variables!");
-  console.error("Please check your .env file and ensure it's loaded correctly.");
+  console.error(
+    "Please check your .env file and ensure it's loaded correctly.",
+  );
 }
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
@@ -51,7 +63,7 @@ function sanitiseHistory(raw) {
       typeof entry.role === "string" &&
       Array.isArray(entry.parts) &&
       entry.parts.length > 0 &&
-      typeof entry.parts[0]?.text === "string"
+      typeof entry.parts[0]?.text === "string",
   );
 }
 
@@ -68,7 +80,9 @@ function buildHistoryBlock(history) {
 
   const capped = history.slice(-MAX_HISTORY_TURNS);
   if (capped.length < history.length) {
-    console.warn(`⚠️ Chat history truncated from ${history.length} to ${MAX_HISTORY_TURNS} turns`);
+    console.warn(
+      `⚠️ Chat history truncated from ${history.length} to ${MAX_HISTORY_TURNS} turns`,
+    );
   }
 
   const lines = capped.map((entry) => {
@@ -86,33 +100,61 @@ const SAFETY_INSTRUCTION = `Important: Always follow the system persona above. D
 
 const MAX_MESSAGE_LENGTH = 500; // characters
 
-const chatSchema = z.object({
-  message: z.string().min(1, { message: 'Message is required' }).max(MAX_MESSAGE_LENGTH, { message: `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer` }),
-}).strict();
+const chatSchema = z
+  .object({
+    message: z
+      .string()
+      .min(1, { message: "Message is required" })
+      .max(MAX_MESSAGE_LENGTH, {
+        message: `Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`,
+      }),
+  })
+  .strict();
 
 router.post("/", chatLimiter, async (req, res) => {
   try {
     // Request validation (from origin/main)
-    if (!req.body || typeof req.body !== 'object') {
-      return res.status(400).json({ error: 'Invalid request', details: ['body: JSON object expected'] });
+    if (!req.body || typeof req.body !== "object") {
+      return res
+        .status(400)
+        .json({
+          error: "Invalid request",
+          details: ["body: JSON object expected"],
+        });
     }
 
     const inputMessage = req.body.message;
-    if (typeof inputMessage !== 'string' || !inputMessage.trim()) {
-      return res.status(400).json({ error: 'Invalid request', details: ['message: Message is required'] });
+    if (typeof inputMessage !== "string" || !inputMessage.trim()) {
+      return res
+        .status(400)
+        .json({
+          error: "Invalid request",
+          details: ["message: Message is required"],
+        });
     }
 
     if (inputMessage.length > MAX_MESSAGE_LENGTH) {
-      return res.status(400).json({ error: 'Invalid request', details: [`message: Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`] });
+      return res
+        .status(400)
+        .json({
+          error: "Invalid request",
+          details: [
+            `message: Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`,
+          ],
+        });
     }
 
     // Schema validation if available (from origin/main)
     let message;
-    if (typeof chatSchema !== 'undefined' && chatSchema) {
+    if (typeof chatSchema !== "undefined" && chatSchema) {
       const parse = chatSchema.safeParse(req.body);
       if (!parse.success) {
-        const issues = parse.error.errors.map(e => `${e.path.join('.')}: ${e.message}`);
-        return res.status(400).json({ error: 'Invalid request', details: issues });
+        const issues = parse.error.errors.map(
+          (e) => `${e.path.join(".")}: ${e.message}`,
+        );
+        return res
+          .status(400)
+          .json({ error: "Invalid request", details: issues });
       }
       message = parse.data.message;
     } else {
@@ -134,17 +176,18 @@ router.post("/", chatLimiter, async (req, res) => {
       let s = input;
 
       // Remove disallowed control characters (keep tab, newline, carriage return)
-      s = s.replace(/[^\x09\x0A\x0D\x20-\x7E\u0080-\uFFFF]/g, '');
+      s = s.replace(/[^\x09\x0A\x0D\x20-\x7E\u0080-\uFFFF]/g, "");
 
       // Collapse 3+ consecutive newlines to 2
-      s = s.replace(/\n{3,}/g, '\n\n');
+      s = s.replace(/\n{3,}/g, "\n\n");
 
       // Collapse excessive whitespace
-      s = s.replace(/[ \t]{3,}/g, ' ');
+      s = s.replace(/[ \t]{3,}/g, " ");
 
       // Neutralize common role-override / prompt-injection phrases
-      const injRegex = /(?:ignore(?: all)? previous instructions?|ignore previous instruction(?:s)?|you are now|act as if|act as|from now on(?:,)?|role[- ]?play as|roleplay as|pretend to be|become|follow these new instructions)/gi;
-      s = s.replace(injRegex, '[redacted]');
+      const injRegex =
+        /(?:ignore(?: all)? previous instructions?|ignore previous instruction(?:s)?|you are now|act as if|act as|from now on(?:,)?|role[- ]?play as|roleplay as|pretend to be|become|follow these new instructions)/gi;
+      s = s.replace(injRegex, "[redacted]");
 
       // Remove fenced code blocks markers to avoid multi-line instruction tricks
       s = s.replace(/```/g, "'");
@@ -158,16 +201,9 @@ router.post("/", chatLimiter, async (req, res) => {
     // Build the full prompt (combining both approaches)
     const historyBlock = buildHistoryBlock(history);
 
-    let prompt;
-    if (typeof SAFETY_INSTRUCTION !== 'undefined' && SAFETY_INSTRUCTION) {
-      // Use the safer prompt construction from origin/main
-      prompt = `${SYSTEM_PROMPT}\n\n${SAFETY_INSTRUCTION}\n\n[USER INPUT START]\n${sanitized}\n[USER INPUT END]`;
-    } else if (historyBlock) {
-      // Use the history-aware prompt from HEAD
-      prompt = `${SYSTEM_PROMPT}\n\nConversation so far:\n${historyBlock}\n\nUser: ${message}`;
-    } else {
-      prompt = `${SYSTEM_PROMPT}\n\nUser: ${message}`;
-    }
+    const prompt = historyBlock
+      ? `${SYSTEM_PROMPT}\n\n${SAFETY_INSTRUCTION}\n\nConversation so far:\n${historyBlock}\n\n[USER INPUT START]\n${sanitized}\n[USER INPUT END]`
+      : `${SYSTEM_PROMPT}\n\n${SAFETY_INSTRUCTION}\n\n[USER INPUT START]\n${sanitized}\n[USER INPUT END]`;
 
     let reply;
     let usedFallback = false;
@@ -186,8 +222,11 @@ router.post("/", chatLimiter, async (req, res) => {
         reply = getFallbackResponse(message);
         usedFallback = true;
       } else if (apiError.message?.includes("API key")) {
-        console.error("❌ API key error - please verify your Gemini API key is valid");
-        reply = "I'm having trouble connecting to my knowledge base. Please check if the **API key** is properly configured. In the meantime, I can still help with **general fitness advice**!";
+        console.error(
+          "❌ API key error - please verify your Gemini API key is valid",
+        );
+        reply =
+          "I'm having trouble connecting to my knowledge base. Please check if the **API key** is properly configured. In the meantime, I can still help with **general fitness advice**!";
         usedFallback = true;
       } else {
         throw apiError;
@@ -195,7 +234,7 @@ router.post("/", chatLimiter, async (req, res) => {
     }
 
     const lower = message.toLowerCase();
-    const wantsProduct = PRODUCT_KEYWORDS.some(kw => lower.includes(kw));
+    const wantsProduct = PRODUCT_KEYWORDS.some((kw) => lower.includes(kw));
 
     if (wantsProduct) {
       try {
@@ -215,7 +254,8 @@ router.post("/", chatLimiter, async (req, res) => {
     }
 
     if (usedFallback) {
-      reply += "\n\n*Note: Using enhanced knowledge base. For more detailed responses, ensure API key has available quota.*";
+      reply +=
+        "\n\n*Note: Using enhanced knowledge base. For more detailed responses, ensure API key has available quota.*";
     }
 
     res.json({ reply });


### PR DESCRIPTION
## Summary

This PR fixes an issue where conversation history was being processed correctly but never included in the final prompt sent to Gemini.

## Root Cause

The prompt construction logic used a mutually exclusive `if / else if` chain.

Since `SAFETY_INSTRUCTION` is defined as a module-level constant and is always truthy, the first branch always executed. As a result, the branch containing `historyBlock` was never reached and conversation history was ignored.

## Changes

* Preserve existing safety instructions
* Preserve existing user input markers
* Include conversation history when available
* Preserve current behavior when history is empty

## Testing

### No History

Verified that requests without history continue to generate the expected prompt structure.

### With History

Verified that conversation history is included before the current user input and is sent to Gemini correctly.

Closes #645 
