### PR TITLE
Increase request payload limit to 1mb

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -106,8 +106,8 @@ app.use(
 );
 
 app.use(helmet());
-app.use(express.json({ limit: "10kb" }));
-app.use(express.urlencoded({ extended: true, limit: "10kb" }));
+app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: true, limit: "1mb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses
 app.disable("etag");
 


### PR DESCRIPTION
## Changes
- Increased express.json limit from 10kb to 1mb.
- Increased express.urlencoded limit from 10kb to 1mb.

## Impact
- Supports larger payloads for profile updates and bulk operations.
- Preserves existing error handling for invalid JSON and oversized requests.