### PR TITLE
fix(auth): remove hardcoded admin uid fallback from frontend bundle

### DIFF
--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
+const ADMIN_UID = import.meta.env.VITE_ADMIN_UID;
 const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
 const DEV_ADMIN_EMAIL = import.meta.env.VITE_DEV_ADMIN_EMAIL || '';
 

--- a/client/src/components/NonAdminRoute.jsx
+++ b/client/src/components/NonAdminRoute.jsx
@@ -3,7 +3,7 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 import ReportBugButton from "./ReportBugButton";
 
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
+const ADMIN_UID = import.meta.env.VITE_ADMIN_UID;
 const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
 
 export default function NonAdminRoute({ children }) {


### PR DESCRIPTION
## 📋 What does this PR do?
Removes hardcoded fallback strings containing a default admin UID (`"n5LtrXIGVSVjNktRn1PgDXZbHgq1"`) from both the `AdminRoute.jsx` and `NonAdminRoute.jsx` client-side guard components[cite: 3]. 

Exposing an admin identifier in the frontend bundle allows any user to inspect the source code and view the identifier, creating a potential vulnerability. This change completely removes static security fallback strings from the client bundle to ensure that privileged access and roles are strictly validated on the backend[cite: 1, 3].

## 🔗 Related Issue
Closes #650

## 🧪 How was this tested?
- Verified locally in the development environment using the local development admin authentication pipeline (`dev_token` flow) to ensure contributor testing flows remain fully functional[cite: 1, 3].
- Manually verified that the client application builds and bundles successfully with Vite without throwing any syntax or path resolution errors.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys