### PR TITLE
fix: unify LOW_STOCK_THRESHOLD across routes and dashboard (fixes #242)

### DIFF
--- a/client/src/constants/inventory.js
+++ b/client/src/constants/inventory.js
@@ -1,0 +1,1 @@
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 
-const LOW_STOCK_THRESHOLD = 5;
+import { LOW_STOCK_THRESHOLD } from "../constants/inventory";
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -8,6 +8,11 @@ PORT=5000
 ALLOWED_ORIGIN=http://localhost:5173
 APP_BASE_URL=http://localhost:5173
 
+# =========================================
+# Business Logic Configuration
+# =========================================
+LOW_STOCK_THRESHOLD=5
+
 
 # =========================================
 # MongoDB Configuration

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -2,7 +2,7 @@
 
 const CONSTANTS = {
   // Stock Thresholds
-  LOW_STOCK_THRESHOLD: 5,
+  LOW_STOCK_THRESHOLD: parseInt(process.env.LOW_STOCK_THRESHOLD, 10) || 5,
 
   // Server Config
   DEFAULT_PORT: 5000,

--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -7,6 +7,7 @@ const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
+const { LOW_STOCK_THRESHOLD } = require('../config/constants');
 
 // ── Helper: get the start date based on the time range filter
 // 'today'  -> start of today
@@ -50,7 +51,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });


### PR DESCRIPTION
Unifies the LOW_STOCK_THRESHOLD magic numbers across the frontend and backend to resolve a silent data consistency bug.

Created a shared frontend constants file (client/src/constants/inventory.js).
Updated the backend to use process.env.LOW_STOCK_THRESHOLD with a fallback of 5 in server/config/constants.js.
Replaced the hardcoded magic number 10 in server/routes/dashboard.js with the centralized backend constant.
Documented the new environment variable in server/.env.example.
🔗 Related Issue
Closes #242

🧪 How was this tested?
Verified that the backend successfully parses the environment variable or falls back to the default of 5.
Verified that the frontend successfully imports and utilizes the new shared constant.
Checked that the dashboard KPI and inventory stock badges now share the exact same threshold logic.