### PR TITLE
refactor(client): remove leftover exercise debug logs

### DIFF
--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -61,17 +61,6 @@ export default function ExercisePage() {
       const data = await response.json();
 
       // Client-side debug logging
-      if (data && data.length > 0) {
-        const firstEx = data[0];
-        console.log(`\n[Exercise Client] Received ${data.length} exercises for "${bodyPart}"`);
-        console.log("  First exercise name:", firstEx.name);
-        console.log("  First exercise gifUrl:", firstEx.gifUrl ? `✅ Present` : "❌ null");
-        console.log("  First exercise imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-        if (firstEx.gifUrl) {
-          console.log("  GIF URL preview:", firstEx.gifUrl.substring(0, 100));
-        }
-        console.log("");
-      }
 
       setExercises(data || []);
     } catch (err) {


### PR DESCRIPTION
## What does this PR do?

Removes leftover debugging logs from `ExercisePage.jsx`.

The logs were used to inspect exercise API responses (exercise count, GIF URL availability, image URL availability, and URL previews) but are no longer required in normal application usage.

## Changes made

* Removed debug `console.log` statements from `ExercisePage.jsx`
* Removed the associated temporary debugging block

## Why?

These logs add noise to the browser console and do not contribute to application functionality.

## Testing

* Verified that the code compiles successfully
* No functional logic was changed
* Exercise fetching and rendering logic remain unchanged
