### PR TITLE
feat: implement debounced product search using useDebounce hook

### DIFF
--- a/client/src/hooks/useDebounce.js
+++ b/client/src/hooks/useDebounce.js
@@ -1,0 +1,15 @@
+import { useState, useEffect } from 'react';
+
+export default function useDebounce(value, delay = 300) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -1,6 +1,6 @@
 
 // src/pages/HomePage.jsx
-import { useState, useEffect, useRef, useMemo, memo } from "react";
+import { useState, useEffect, useMemo, memo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import Navbar from "../components/Navbar";
 import { signOut } from "firebase/auth";
@@ -19,7 +19,7 @@ import Stars from "../components/Stars";
 import ProductCardSkeleton from "../components/ProductCardSkeleton";
 import useInfiniteProducts from "../hooks/useInfiniteProducts";
 import CategoryPillsSkeleton from "../components/CategoryPillsSkeleton";
-
+import useDebounce from '../hooks/useDebounce';
 
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
@@ -185,8 +185,7 @@ export default function HomePage() {
   const [cart, setCart] = useState([]);
   const [cartOpen, setCartOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState("");
-  const debounceRef = useRef(null);
+  const debouncedQuery = useDebounce(searchQuery, 300);
   const [menuOpen, setMenuOpen] = useState(false);
   const [visible, setVisible] = useState(false);
   const [products, setProducts] = useState([]);
@@ -195,12 +194,6 @@ export default function HomePage() {
   const [showAll, setShowAll] = useState(false);
 
   const { showBanner, dismissBanner } = useWelcomeDiscount(user);
-
-  useEffect(() => {
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => setDebouncedQuery(searchQuery), 300);
-    return () => clearTimeout(debounceRef.current);
-  }, [searchQuery]);
 
   useEffect(() => { document.title = "FitMart - Fitness & Nutrition Store"; }, []);
 
@@ -221,7 +214,7 @@ export default function HomePage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteProducts({ limit: 24 });
+  } = useInfiniteProducts({ limit: 24, search: debouncedQuery });
 
   useEffect(() => {
     setLoading(rqLoading);


### PR DESCRIPTION
Closes #584

- Created reusable `useDebounce` hook in `client/src/hooks/useDebounce.js`
- Replaced manual setTimeout/useRef debounce logic in HomePage.jsx with the new hook
- Passed `debouncedQuery` to `useInfiniteProducts` so API calls are also debounced
- Search now waits 300ms after user stops typing before firing API request
- Removed unused `useRef` import from HomePage.jsx