### PR TITLE
fix: restrict development admin access to configured dev admin email

### DIFF
--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -12,10 +12,15 @@ export default function AdminRoute({ children }) {
   if (loading) return null;
   if (!user) return <Navigate to="/auth" replace />;
   // In development allow a local dev admin session
-  if (import.meta.env.MODE === 'development') {
-    const isDevLocal = localStorage.getItem('dev_token') && (DEV_ADMIN_EMAIL ? true : true);
-    if (isDevLocal) return children;
-  }
+  // In development allow access only to the configured dev admin email
+if (import.meta.env.MODE === "development") {
+  const isDevLocal =
+    localStorage.getItem("dev_token") &&
+    DEV_ADMIN_EMAIL &&
+    user?.email === DEV_ADMIN_EMAIL;
+
+  if (isDevLocal) return children;
+}
 
   if (user.uid !== ADMIN_UID && user.uid !== SUPER_ADMIN_UID) return <Navigate to="/home" replace />;
   return children;


### PR DESCRIPTION
## 📋 What does this PR do?

Fixes a security issue in `client/src/components/AdminRoute.jsx`.

Previously, development admin access relied on:

```js
const isDevLocal = localStorage.getItem('dev_token') && (DEV_ADMIN_EMAIL ? true : true);
```

Since `(DEV_ADMIN_EMAIL ? true : true)` always evaluates to `true`, any user with a manually created `dev_token` in localStorage could bypass admin checks during development.

This PR restricts development admin access to users whose email matches the configured `VITE_DEV_ADMIN_EMAIL`, ensuring that only the intended development admin account can access protected admin routes during local development.

## 🔗 Related Issue

Closes #685 

## 🧪 How was this tested?

Manual testing:

1. Started the application in development mode.
2. Verified that access to admin routes is granted when:
   - `dev_token` exists in localStorage.
   - The authenticated user's email matches `VITE_DEV_ADMIN_EMAIL`.
3. Verified that access is denied when:
   - `dev_token` is absent.
   - The authenticated user's email does not match `VITE_DEV_ADMIN_EMAIL`.
4. Confirmed that production admin authentication behavior remains unchanged.

## 📸 Screenshots (if UI changes)

N/A (No UI changes)

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys