### PR TITLE
docs: remove unsupported PWA Ready claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Whether you're a beginner learning full-stack development or an experienced deve
 | 🏋️ Fitness Plans | Weight Loss, Muscle Building, and Mobility & Recovery plans |
 | 🐛 Bug Reporter | In-app bug reporting widget available to all signed-in users |
 | 📧 Welcome Email | Automated first-purchase congratulations email |
-| 📱 PWA Ready | Progressive Web App support for mobile installation |
+
 
 ### Admin-Facing
 
@@ -1024,3 +1024,7 @@ Made with ❤️ by [Parth Narkar](https://github.com/parthnarkar) and the [Part
 ⭐ **Star this repo** if you find it useful — it helps a lot!
 
 </div>
+
+## Contribution
+
+Thank you to the open-source community for supporting FitMart.


### PR DESCRIPTION
## 📄 What does this PR do?

Removes the unsupported "PWA Ready" feature claim from the README.

The project currently does not include:

* vite-plugin-pwa
* a web app manifest
* a service worker

This change keeps the documentation aligned with the actual functionality available in the repository.

## 🔗 Related Issue

Closes #684

## 🧪 How was this tested?

* Verified that the README contained a "PWA Ready" feature entry.
* Searched the repository for:

  * vite-plugin-pwa
  * manifest.webmanifest
  * serviceWorker
* Confirmed that no PWA implementation currently exists.
* Removed the misleading feature claim from the README.

## 📸 Screenshots (if UI changes)

N/A (documentation-only change)

## ✅ Checklist

* [x] I've read the CONTRIBUTING guide
* [x] My code follows the project's style guidelines
* [x] I've tested my changes locally
* [x] I've linked the related issue
* [x] I haven't introduced any new secrets or API keys
