### PR TITLE
docs: remove unsupported PWA Ready claim from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ Whether you're a beginner learning full-stack development or an experienced deve
 | 👤 User Profile | Manage personal info, shipping addresses, and default address |
 | 🏋️ Fitness Plans | Weight Loss, Muscle Building, and Mobility & Recovery plans |
 | 🐛 Bug Reporter | In-app bug reporting widget available to all signed-in users |
-| 📧 Welcome Email | Automated first-purchase congratulations email |
-| 📱 PWA Ready | Progressive Web App support for mobile installation |
+| 📧 Welcome Email | Automated first-purchase congratula
 
 ### Admin-Facing
 


### PR DESCRIPTION
## 📋 What does this PR do?
Removed the "PWA Ready" row from README.md because the repository does not contain a web app manifest, service worker, or vite-plugin-pwa setup.

## 🔗 Related Issue
Closes #684

## 🧪 How was this tested?
Checked README.md locally and verified the table renders correctly after removing the PWA row.

## 📸 Screenshots (if UI changes)
Not applicable (documentation change only)

## ✅ Checklist
- [✅ ] I've read the CONTRIBUTING guide
- [✅ ] My code follows the project's style guidelines
- [✅ ] I've tested my changes locally
- [✅ ] I've linked the related issue
- [✅ ] I haven't introduced any new secrets or API keys