### PR TITLE
Fix pwa readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Whether you're a beginner learning full-stack development or an experienced deve
 | 🏋️ Fitness Plans | Weight Loss, Muscle Building, and Mobility & Recovery plans |
 | 🐛 Bug Reporter | In-app bug reporting widget available to all signed-in users |
 | 📧 Welcome Email | Automated first-purchase congratulations email |
-| 📱 PWA Ready | Progressive Web App support for mobile installation |
 
 ### Admin-Facing
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Whether you're a beginner learning full-stack development or an experienced deve
 | 🏋️ Fitness Plans | Weight Loss, Muscle Building, and Mobility & Recovery plans |
 | 🐛 Bug Reporter | In-app bug reporting widget available to all signed-in users |
 | 📧 Welcome Email | Automated first-purchase congratulations email |
+| 🧙   Planned PWA Support |
 
 ### Admin-Facing
 


### PR DESCRIPTION
## 📋 What does this PR do?
Removes the unsupported "PWA Ready" claim from the README documentation.

The repository currently does not include:

A Web App Manifest (manifest.json or manifest.webmanifest)
A Service Worker
vite-plugin-pwa configuration
Offline support or installable PWA functionality

This change ensures that the project documentation accurately reflects the current implementation and avoids misleading users and contributors.

## 🔗 Related Issue
Closes #684

## 🧪 How was this tested?
Verified the README contained a "PWA Ready" feature claim.
Checked the repository for PWA-related files and configuration.
Confirmed that no manifest, service worker, or PWA plugin configuration exists.
Updated the README and reviewed the rendered Markdown locally.

## 📸 Screenshots (if UI changes)
Before / After screenshots if you changed any UI.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys