### PR TITLE
perf: lazy-load images app-wide to improve LCP and reduce initial payload

### DIFF
--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -103,6 +103,8 @@ export default function AdminNavbar({ range, setRange, menuOpen, setMenuOpen }) 
                       alt={user.displayName || "Admin profile picture"}
                       className="w-full h-full object-cover"
                       referrerPolicy="no-referrer"
+                      loading="lazy"
+                      decoding="async"
                     />
                   ) : (
                     <span className="text-[11px] font-medium text-stone-600">

--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -123,6 +123,8 @@ function CartDrawer({
                         src={item.image}
                         alt={item.name}
                         className="w-full h-full object-cover"
+                        loading="lazy"
+                        decoding="async"
                         onError={(e) => {
                           e.currentTarget.onerror = null;
                           e.currentTarget.style.display = "none";

--- a/client/src/components/FitnessCenterDetail.jsx
+++ b/client/src/components/FitnessCenterDetail.jsx
@@ -25,7 +25,7 @@ export default function FitnessCenterDetail({ center }) {
     <div className="bg-white rounded-2xl p-6 flex flex-col md:flex-row gap-6">
       <div className="w-full md:w-1/3 rounded-xl overflow-hidden bg-stone-100 flex items-center justify-center">
         {center.imageUrl ? (
-          <img src={center.imageUrl} alt={center.name} className="w-full h-48 object-cover" onError={e => e.currentTarget.style.display = 'none'} />
+          <img src={center.imageUrl} alt={center.name} className="w-full h-48 object-cover" loading="lazy" decoding="async" onError={e => e.currentTarget.style.display = 'none'} />
         ) : (
           <div className="text-4xl opacity-20">🏋️</div>
         )}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -158,6 +158,8 @@ export default function Navbar({
                           alt={user.displayName || "User profile picture"}
                           className="w-full h-full object-cover"
                           referrerPolicy="no-referrer"
+                          loading="lazy"
+                          decoding="async"
                         />
                       ) : (
                         <span className={`text-[11px] font-medium ${isLanding && !navOpaque ? "text-stone-700" : "text-stone-600"}`} aria-hidden>

--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -93,7 +93,7 @@ export default function NearbyFitnessCenters({ visible = true }) {
 
               <div className="flex gap-3">
                 <div className="w-20 h-20 bg-stone-100 rounded-xl overflow-hidden shrink-0">
-                  <img src={c.imageUrl} alt={c.name} className="w-full h-full object-cover" onError={e => e.currentTarget.style.display = 'none'} />
+                  <img src={c.imageUrl} alt={c.name} className="w-full h-full object-cover" loading="lazy" decoding="async" onError={e => e.currentTarget.style.display = 'none'} />
                 </div>
                 <div className="flex-1">
                   <div className="flex items-start justify-between gap-2">

--- a/client/src/pages/AdminCustomerDetail.jsx
+++ b/client/src/pages/AdminCustomerDetail.jsx
@@ -31,6 +31,8 @@ const CustomerAvatar = ({ name, photoURL, sizePx = 64 }) => (
         alt={name || "avatar"}
         className="w-full h-full object-cover"
         referrerPolicy="no-referrer"
+        loading="lazy"
+        decoding="async"
         onError={e => { e.currentTarget.style.display = "none"; }}
       />
     ) : (

--- a/client/src/pages/AdminCustomers.jsx
+++ b/client/src/pages/AdminCustomers.jsx
@@ -19,6 +19,7 @@ const CustomerAvatar = ({ name, photoURL, size = 8 }) => (
     {photoURL ? (
       <img src={photoURL} alt={name || "avatar"}
         className="w-full h-full object-cover" referrerPolicy="no-referrer"
+        loading="lazy" decoding="async"
         onError={e => { e.currentTarget.style.display = "none"; }} />
     ) : (
       <span className="text-xs font-medium text-stone-600">

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -91,6 +91,7 @@ const CustomerAvatar = ({ name, photoURL }) => (
     {photoURL ? (
       <img src={photoURL} alt={name || "avatar"}
         className="w-full h-full object-cover" referrerPolicy="no-referrer"
+        loading="lazy" decoding="async"
         onError={e => { e.currentTarget.style.display = "none"; }} />
     ) : (
       <span className="text-[11px] font-medium text-stone-600">

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -54,6 +54,8 @@ const InventoryMobileCard = ({ p, onEdit }) => {
         <div className="w-12 h-12 rounded-xl bg-stone-100 overflow-hidden shrink-0">
           <img src={p.image} alt={p.name}
             className="w-full h-full object-cover"
+            loading="lazy"
+            decoding="async"
             onError={e => { e.currentTarget.style.display = "none"; }} />
         </div>
       )}
@@ -372,6 +374,8 @@ export default function AdminInventory() {
                           {p.image && (
                             <div className="w-9 h-9 rounded-xl bg-stone-100 overflow-hidden shrink-0">
                               <img src={p.image} alt={p.name}
+                                loading="lazy"
+                                decoding="async"
                                 className="w-full h-full object-cover"
                                 onError={e => { e.currentTarget.style.display = "none"; }} />
                             </div>

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -637,6 +637,8 @@ export default function ProductPage() {
                       <div className="relative bg-stone-100 aspect-square overflow-hidden">
                         {rel.image ? (
                           <img src={rel.image} alt={rel.name}
+                            loading="lazy"
+                            decoding="async"
                             className="related-img w-full h-full object-cover" />
                         ) : (
                           <div className="w-full h-full flex items-center justify-center

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -46,7 +46,8 @@ function Avatar({ name, photoURL, size = 96 }) {
       style={{ width: size, height: size, minWidth: size }}
     >
       {photoURL ? (
-        <img src={photoURL} alt={name} className="w-full h-full object-cover" />
+        <img src={photoURL} alt={name} className="w-full h-full object-cover" 
+        loading="lazy" decoing="async" />
       ) : (
         <span
           style={{ fontFamily: "'DM Serif Display', serif", fontSize: size * 0.36 }}


### PR DESCRIPTION
Closes #696

Added `loading="lazy"` and `decoding="async"` to off-screen `<img>` tags across the client:

- AdminNavbar.jsx — user profile avatar
- CartDrawer.jsx — cart item product images
- FitnessCenterDetail.jsx — fitness center image
- Navbar.jsx — user profile avatar
- NearbyFitnessCenters.jsx — fitness center card images
- AdminCustomerDetail.jsx — customer avatar
- AdminCustomers.jsx — customer avatar
- AdminDashboard.jsx — customer avatar
- AdminInventory.jsx — product images (mobile card + desktop table)
- ProductPage.jsx — related product images (hero image kept eager)
- Profile.jsx — user avatar

Hero/above-the-fold images are intentionally kept eager to avoid LCP regression.