### PR TITLE
fix: Move QueryClient to module scope to prevent recreation on every render

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -30,8 +30,19 @@ import LegalTerms from "./pages/LegalTerms";
 import LegalPrivacy from "./pages/LegalPrivacy";
 import DevAdminLogin from "./components/DevAdminLogin";
 
+// Stable QueryClient instance at module scope — survives re-renders so
+// React Query's cache, deduplication, and background refetching work correctly.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5, // 5 minutes before data is considered stale
+      retry: 1,                  // retry failed queries once
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 export default function App() {
-  const queryClient = new QueryClient();
   return (
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## Summary

Fixes #698

**Problem:** 
ew QueryClient() was called inside the App() component body, meaning a brand-new client (and empty cache) was created on every render. This completely defeats React Query's caching, request deduplication, and background refetching.

**Fix:**
- Moved QueryClient instantiation to **module scope** (outside the component) so a single stable instance lives for the app's lifetime
- Added sensible default options:
  - staleTime: 5 minutes — avoids unnecessary refetches for recently loaded data
  - etry: 1 — retries failed queries once before surfacing the error
  - efetchOnWindowFocus: false — prevents surprise refetches when tabbing back

## Changes
- client/src/App.jsx — moved 
ew QueryClient(...) from inside App() to module scope with default options

Closes #698