### PR TITLE
feat: Implement PWA support with vite-plugin-pwa

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,18 +3,25 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/logo.png" />
+  <link rel="icon" type="image/png" href="/logo.png" />
 
   <!-- SEO META TAGS -->
   <title>FitMart - Fitness Equipment, Nutrition & Coaching</title>
 
   <meta name="description"
-    content="FitMart is Mumbai’s fitness marketplace offering gym equipment, supplements, and personalized fitness plans. Shop smart and achieve your fitness goals." />
+    content="FitMart is Mumbai's fitness marketplace offering gym equipment, supplements, and personalized fitness plans. Shop smart and achieve your fitness goals." />
 
   <meta name="keywords"
     content="fitness, gym equipment, protein, supplements, workout, fitness plans, Mumbai fitness, FitMart" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+
+  <!-- PWA META TAGS -->
+  <meta name="theme-color" content="#1c1917" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="FitMart" />
+  <link rel="apple-touch-icon" href="/logo.png" />
 
   <!-- OPTIONAL (extra marks 🔥) -->
   <meta name="author" content="FitMart Team" />

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
-    "vite": "^7.3.1"
+    "vite": "^7.3.1",
+    "vite-plugin-pwa": "^0.21.1"
   }
 }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,8 +1,107 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss(),],
+  plugins: [
+    react(),
+    tailwindcss(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      includeAssets: ['logo.png', 'assets/placeholder-product.png'],
+      manifest: {
+        name: 'FitMart - Fitness Equipment & Nutrition',
+        short_name: 'FitMart',
+        description: 'Fitness marketplace offering gym equipment, supplements, and personalized fitness plans.',
+        theme_color: '#1c1917',
+        background_color: '#fafaf9',
+        display: 'standalone',
+        scope: '/',
+        start_url: '/',
+        icons: [
+          {
+            src: '/logo.png',
+            sizes: '192x192',
+            type: 'image/png',
+          },
+          {
+            src: '/logo.png',
+            sizes: '512x512',
+            type: 'image/png',
+          },
+          {
+            src: '/logo.png',
+            sizes: '512x512',
+            type: 'image/png',
+            purpose: 'maskable',
+          },
+        ],
+      },
+      workbox: {
+        // Cache static assets (JS, CSS, images, fonts)
+        globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+        runtimeCaching: [
+          {
+            // Cache API responses with network-first strategy
+            urlPattern: /^https?:\/\/.*\/api\/.*/i,
+            handler: 'NetworkFirst',
+            options: {
+              cacheName: 'api-cache',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 5, // 5 minutes
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Cache Google Fonts
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-cache',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Cache font files
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'gstatic-fonts-cache',
+              expiration: {
+                maxEntries: 10,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 1 year
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+          {
+            // Cache product images
+            urlPattern: /\.(?:png|jpg|jpeg|svg|gif|webp)$/i,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'image-cache',
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 60 * 60 * 24 * 30, // 30 days
+              },
+            },
+          },
+        ],
+      },
+    }),
+  ],
 })


### PR DESCRIPTION
## Summary

Fixes #684

Implements actual PWA support so the README's "PWA Ready" claim is accurate. The app is now installable on mobile/desktop and has offline caching capabilities.

## Changes

### client/vite.config.js
- Added `vite-plugin-pwa` with `registerType: 'autoUpdate'`
- Configured web app manifest (app name, icons, theme color, `display: standalone`)
- Workbox runtime caching strategies:
  - **NetworkFirst** for API requests (cached 5 min as fallback)
  - **CacheFirst** for Google Fonts (1 year cache)
  - **StaleWhileRevalidate** for images (30 day cache, 100 max entries)
- Static assets (JS, CSS, HTML, images) are precached at build time

### client/index.html
- Added `theme-color` meta tag
- Added Apple PWA meta tags (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`, `apple-mobile-web-app-title`)
- Added `apple-touch-icon` link
- Fixed favicon type from `image/svg+xml` to `image/png`

### client/package.json
- Added `vite-plugin-pwa: ^0.21.1` to devDependencies

## What This Enables
- Install prompt on Chrome, Edge, Safari (mobile + desktop)
- Offline shell - cached pages load even without network
- Background SW auto-update without user intervention
- Efficient caching: fonts cached long-term, API cached short-term, images revalidated

## Setup
After pulling this branch, run `npm install` in the `client/` directory to install the new dependency.

Closes #684
