### PR TITLE
feat: Implement 6-month points expiry logic via daily cron job

### DIFF
--- a/server/config/rewardsConfig.js
+++ b/server/config/rewardsConfig.js
@@ -4,6 +4,10 @@ module.exports = {
   WORKOUT_POINTS: 25,
   MILESTONE_POINTS: 50,
 
+  // Points expiry configuration
+  EXPIRY_MONTHS: 6,                    // points expire after 6 months
+  EXPIRY_CRON_SCHEDULE: "0 0 * * *",  // run daily at midnight
+
   TIERS: [
     { name: "Bronze", minPoints: 0 },
     { name: "Silver", minPoints: 500 },

--- a/server/index.js
+++ b/server/index.js
@@ -123,6 +123,10 @@ app.use("/api/payment/verify-payment", paymentLimiter);
 // ── Database ────────────────────────────────────────────────────────────────
 require("./db");
 
+// ── Scheduled jobs ──────────────────────────────────────────────────────────
+const { startExpiryCron } = require("./jobs/rewardsExpiry");
+startExpiryCron();
+
 // ── Development: seed a local admin profile if configured ──────────────────
 if (process.env.NODE_ENV !== 'production') {
   try {

--- a/server/jobs/rewardsExpiry.js
+++ b/server/jobs/rewardsExpiry.js
@@ -1,0 +1,182 @@
+// server/jobs/rewardsExpiry.js
+// Daily cron job that expires FitRewards points older than 6 months.
+// Uses FIFO accounting: redemptions are applied against the oldest earned
+// transactions first, so only truly unspent points get expired.
+
+const cron = require("node-cron");
+const Rewards = require("../models/Rewards");
+const rewardsConfig = require("../config/rewardsConfig");
+
+/**
+ * Calculate how many points from a specific earn transaction remain unspent,
+ * using FIFO ordering (oldest points are redeemed first).
+ *
+ * @param {Array} transactions - Full sorted transactions array (oldest first)
+ * @param {number} earnIndex   - Index of the earn transaction to check
+ * @returns {number} Unredeemed points remaining for that transaction
+ */
+function getUnredeemedPoints(transactions, earnIndex) {
+  const earnTx = transactions[earnIndex];
+  if (earnTx.type !== "earned") return 0;
+
+  // Sum all earned points from transactions at or before this index
+  let totalEarnedUpToHere = 0;
+  for (let i = 0; i <= earnIndex; i++) {
+    if (transactions[i].type === "earned") {
+      totalEarnedUpToHere += transactions[i].points;
+    }
+  }
+
+  // Sum all redeemed + expired points across ALL transactions (they consume oldest first)
+  let totalSpent = 0;
+  for (const tx of transactions) {
+    if (tx.type === "redeemed" || tx.type === "expired") {
+      totalSpent += tx.points;
+    }
+  }
+
+  // Points consumed from transactions up to and including this one
+  const spentFromOlder = Math.min(totalSpent, totalEarnedUpToHere);
+
+  // Points consumed from transactions strictly before this one
+  let earnedBeforeThis = 0;
+  for (let i = 0; i < earnIndex; i++) {
+    if (transactions[i].type === "earned") {
+      earnedBeforeThis += transactions[i].points;
+    }
+  }
+  const spentFromBeforeThis = Math.min(totalSpent, earnedBeforeThis);
+
+  // Points from THIS transaction that have been spent
+  const spentFromThis = spentFromOlder - spentFromBeforeThis;
+
+  return Math.max(0, earnTx.points - spentFromThis);
+}
+
+/**
+ * Process point expiry for all users.
+ * Finds earn transactions older than EXPIRY_MONTHS, calculates remaining
+ * unspent points using FIFO, and creates "expired" debit entries.
+ */
+async function processExpiry() {
+  const expiryDate = new Date();
+  expiryDate.setMonth(expiryDate.getMonth() - rewardsConfig.EXPIRY_MONTHS);
+
+  console.log(`[RewardsExpiry] Running expiry job. Expiring points earned before ${expiryDate.toISOString()}`);
+
+  // Find all users who have at least one earn transaction older than the expiry threshold
+  const usersWithOldPoints = await Rewards.find({
+    "transactions": {
+      $elemMatch: {
+        type: "earned",
+        createdAt: { $lt: expiryDate },
+      },
+    },
+  });
+
+  let totalUsersProcessed = 0;
+  let totalPointsExpired = 0;
+
+  for (const rewards of usersWithOldPoints) {
+    // Sort transactions by date (oldest first) for FIFO accounting
+    const sorted = [...rewards.transactions].sort(
+      (a, b) => new Date(a.createdAt) - new Date(b.createdAt)
+    );
+
+    let pointsToExpire = 0;
+    const expiredTxIds = [];
+
+    for (let i = 0; i < sorted.length; i++) {
+      const tx = sorted[i];
+      if (tx.type !== "earned") continue;
+      if (new Date(tx.createdAt) >= expiryDate) continue;
+
+      // Check if this transaction was already expired in a previous run
+      const alreadyExpired = sorted.some(
+        (t) =>
+          t.type === "expired" &&
+          t.description &&
+          t.description.includes(String(tx._id))
+      );
+      if (alreadyExpired) continue;
+
+      const unredeemed = getUnredeemedPoints(sorted, i);
+      if (unredeemed > 0) {
+        pointsToExpire += unredeemed;
+        expiredTxIds.push(String(tx._id));
+      }
+    }
+
+    if (pointsToExpire <= 0) continue;
+
+    // Atomically deduct expired points and add expiry transaction
+    const updated = await Rewards.findOneAndUpdate(
+      { _id: rewards._id, pointsBalance: { $gte: pointsToExpire } },
+      {
+        $inc: { pointsBalance: -pointsToExpire },
+        $push: {
+          transactions: {
+            type: "expired",
+            points: pointsToExpire,
+            source: "purchase",
+            description: `${pointsToExpire} points expired (6-month policy). Refs: ${expiredTxIds.join(", ")}`,
+            createdAt: new Date(),
+          },
+        },
+      },
+      { new: true }
+    );
+
+    if (updated) {
+      totalUsersProcessed++;
+      totalPointsExpired += pointsToExpire;
+    } else {
+      // Balance was less than expected (possibly concurrent redemption).
+      // Expire only what's available.
+      const current = await Rewards.findById(rewards._id);
+      if (current && current.pointsBalance > 0) {
+        const safeExpiry = Math.min(pointsToExpire, current.pointsBalance);
+        await Rewards.findByIdAndUpdate(rewards._id, {
+          $inc: { pointsBalance: -safeExpiry },
+          $push: {
+            transactions: {
+              type: "expired",
+              points: safeExpiry,
+              source: "purchase",
+              description: `${safeExpiry} points expired (6-month policy, adjusted). Refs: ${expiredTxIds.join(", ")}`,
+              createdAt: new Date(),
+            },
+          },
+        });
+        totalUsersProcessed++;
+        totalPointsExpired += safeExpiry;
+      }
+    }
+  }
+
+  console.log(
+    `[RewardsExpiry] Complete. Users processed: ${totalUsersProcessed}, Points expired: ${totalPointsExpired}`
+  );
+
+  return { totalUsersProcessed, totalPointsExpired };
+}
+
+/**
+ * Start the cron job scheduler.
+ * Call this once from server/index.js after DB connection is established.
+ */
+function startExpiryCron() {
+  const schedule = rewardsConfig.EXPIRY_CRON_SCHEDULE;
+
+  cron.schedule(schedule, async () => {
+    try {
+      await processExpiry();
+    } catch (err) {
+      console.error("[RewardsExpiry] Cron job failed:", err.message);
+    }
+  });
+
+  console.log(`[RewardsExpiry] Cron job scheduled: "${schedule}"`);
+}
+
+module.exports = { startExpiryCron, processExpiry };

--- a/server/models/Rewards.js
+++ b/server/models/Rewards.js
@@ -4,7 +4,7 @@ const rewardTransactionSchema = new mongoose.Schema(
   {
     type: {
       type: String,
-      enum: ["earned", "redeemed"],
+      enum: ["earned", "redeemed", "expired"],
       default: "earned",
     },
     points: {

--- a/server/package.json
+++ b/server/package.json
@@ -22,6 +22,7 @@
     "helmet": "^8.2.0",
     "mongoose": "^7.0.0",
     "multer": "^2.1.1",
+    "node-cron": "^3.0.3",
     "nodemailer": "^8.0.10",
     "razorpay": "^2.9.6",
     "redis": "^6.0.0",

--- a/server/routes/rewards.js
+++ b/server/routes/rewards.js
@@ -137,4 +137,26 @@ router.post("/earn", verifyFirebaseToken, async (req, res) => {
   }
 });
 
+/**
+ * @route   POST /expire
+ * @desc    Manually trigger the points expiry job (admin only)
+ * @access  Private (admin)
+ */
+const verifyAdmin = require("../middleware/verifyAdmin");
+
+router.post("/expire", verifyFirebaseToken, verifyAdmin, async (req, res) => {
+  try {
+    const { processExpiry } = require("../jobs/rewardsExpiry");
+    const result = await processExpiry();
+    return res.status(200).json({
+      success: true,
+      message: "Expiry job completed",
+      ...result,
+    });
+  } catch (error) {
+    console.error("Manual expiry error:", error);
+    return res.status(500).json({ message: "Failed to run expiry job" });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary

Fixes #544

Implements a daily cron job that expires FitRewards points older than 6 months, using FIFO accounting to ensure only truly unspent points are expired.

## Changes

### New Files
- **server/jobs/rewardsExpiry.js** - The core expiry logic and cron scheduler

### Modified Files
- **server/config/rewardsConfig.js** - Added `EXPIRY_MONTHS: 6` and `EXPIRY_CRON_SCHEDULE: "0 0 * * *"` (daily at midnight)
- **server/models/Rewards.js** - Added `"expired"` to the transaction type enum
- **server/package.json** - Added `node-cron: ^3.0.3` dependency
- **server/index.js** - Registers the cron job after DB connection
- **server/routes/rewards.js** - Added admin-only `POST /api/rewards/expire` endpoint for manual trigger

## How the Expiry Logic Works

1. Cron runs daily at midnight
2. Finds all users with earn transactions older than 6 months
3. For each expired earn transaction, uses FIFO accounting to determine unredeemed points:
   - Redemptions consume oldest earned points first
   - Only the remaining unspent portion gets expired
4. Creates an "expired" debit transaction with references to the original earn transaction IDs
5. Atomically deducts from pointsBalance with optimistic concurrency (prevents double-deduction if a user redeems mid-job)
6. Tracks which transactions have already been expired to prevent duplicate processing

## Concurrency Safety
- Uses `findOneAndUpdate` with `pointsBalance: { $gte: amount }` condition for atomic deduction
- If balance changed between read and write (concurrent redemption), falls back to expiring only what's available
- Expired transaction IDs are recorded in the description to prevent double-expiry on subsequent runs

## Configuration
- `EXPIRY_MONTHS: 6` - Points expire after 6 months
- `EXPIRY_CRON_SCHEDULE: "0 0 * * *"` - Runs daily at midnight (cron syntax, configurable)

## Admin Manual Trigger
`POST /api/rewards/expire` (requires Firebase auth + admin role) allows admins to run the expiry job on demand for testing or catch-up processing.

## Setup
After pulling, run `npm install` in the `server/` directory to install `node-cron`.

Closes #544
