### PR TITLE
fix(chat): include conversation history in Gemini prompt

### DIFF
--- a/server/routes/chat.js
+++ b/server/routes/chat.js
@@ -106,18 +106,14 @@ router.post("/", chatLimiter, async (req, res) => {
       return res.status(400).json({ error: 'Invalid request', details: [`message: Message must be ${MAX_MESSAGE_LENGTH} characters or fewer`] });
     }
 
-    // Schema validation if available (from origin/main)
+    // Schema validation
     let message;
-    if (typeof chatSchema !== 'undefined' && chatSchema) {
-      const parse = chatSchema.safeParse(req.body);
-      if (!parse.success) {
-        const issues = parse.error.errors.map(e => `${e.path.join('.')}: ${e.message}`);
-        return res.status(400).json({ error: 'Invalid request', details: issues });
-      }
-      message = parse.data.message;
-    } else {
-      message = inputMessage;
+    const parse = chatSchema.safeParse(req.body);
+    if (!parse.success) {
+      const issues = parse.error.errors.map(e => `${e.path.join('.')}: ${e.message}`);
+      return res.status(400).json({ error: 'Invalid request', details: issues });
     }
+    message = parse.data.message;
 
     // History handling (from HEAD)
     const { history: rawHistory } = req.body;
@@ -155,19 +151,17 @@ router.post("/", chatLimiter, async (req, res) => {
 
     const sanitized = sanitizeMessage(message);
 
-    // Build the full prompt (combining both approaches)
+    // Build the full prompt — always include safety instruction and history when present
     const historyBlock = buildHistoryBlock(history);
 
-    let prompt;
-    if (typeof SAFETY_INSTRUCTION !== 'undefined' && SAFETY_INSTRUCTION) {
-      // Use the safer prompt construction from origin/main
-      prompt = `${SYSTEM_PROMPT}\n\n${SAFETY_INSTRUCTION}\n\n[USER INPUT START]\n${sanitized}\n[USER INPUT END]`;
-    } else if (historyBlock) {
-      // Use the history-aware prompt from HEAD
-      prompt = `${SYSTEM_PROMPT}\n\nConversation so far:\n${historyBlock}\n\nUser: ${message}`;
-    } else {
-      prompt = `${SYSTEM_PROMPT}\n\nUser: ${message}`;
-    }
+    const prompt = [
+      SYSTEM_PROMPT,
+      SAFETY_INSTRUCTION,
+      historyBlock ? `Conversation so far:\n${historyBlock}` : "",
+      `[USER INPUT START]\n${sanitized}\n[USER INPUT END]`,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
 
     let reply;
     let usedFallback = false;


### PR DESCRIPTION
## Summary

Fixes #645

The chatbot's conversation history was never included in the prompt sent to Gemini, making every message treated as the first in a new conversation.

## Root Cause

In `server/routes/chat.js`, the prompt was built with an `if / else if` chain:

```javascript
if (typeof SAFETY_INSTRUCTION !== 'undefined' && SAFETY_INSTRUCTION) {
  // Always true — SAFETY_INSTRUCTION is a module-level constant string
  prompt = `${SYSTEM_PROMPT}\n\n${SAFETY_INSTRUCTION}\n\n[USER INPUT START]...`;
} else if (historyBlock) {
  // NEVER reached — history is always ignored
  prompt = `${SYSTEM_PROMPT}\n\nConversation so far:\n${historyBlock}...`;
}
```

Since `SAFETY_INSTRUCTION` is always truthy, the history branch never executed.

## Fix

Replaced the broken branching with a single array-based prompt builder that always includes both safety instruction AND history:

```javascript
const prompt = [
  SYSTEM_PROMPT,
  SAFETY_INSTRUCTION,
  historyBlock ? `Conversation so far:\n${historyBlock}` : "",
  `[USER INPUT START]\n${sanitized}\n[USER INPUT END]`,
]
  .filter(Boolean)
  .join("\n\n");
```

Also removed the redundant `typeof chatSchema !== 'undefined'` guard since `chatSchema` is always defined at module scope.

## Result
- Multi-turn conversations now maintain context across messages
- Safety instruction is still always present (prompt injection protection intact)
- Single-message requests (no history) continue to work correctly

Closes #645
