### PR TITLE
fix(ci): Remove || true from backend tests so failures block PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,4 +93,4 @@ jobs:
       
       - name: Run server tests
         working-directory: server
-        run: npm test --silent || true  # Temporarily don't fail
+        run: npm test --silent

--- a/server/routes/cart.js
+++ b/server/routes/cart.js
@@ -200,3 +200,4 @@ router.delete('/:userId', verifyFirebaseToken, async (req, res) => {
 });
 
 module.exports = router;
+module.exports.adjustReserved = adjustReserved;

--- a/server/tests/cart.reserved.test.js
+++ b/server/tests/cart.reserved.test.js
@@ -21,15 +21,10 @@ let mongoServer;
 
 beforeAll(async () => {
   // Start the in-memory MongoDB server
-  // This downloads the MongoDB binary on first run (~10–30 seconds)
-  // Subsequent runs use a cached binary and start in < 1 second
-  process.env.MONGOMS_SYSTEM_BINARY = 'C:\\Program Files\\MongoDB\\Server\\8.0\\bin\\mongod.exe';
   mongoServer = await MongoMemoryServer.create();
   const uri = mongoServer.getUri();
 
   // Connect Mongoose to the in-memory server
-  // useNewUrlParser and useUnifiedTopology are no longer needed in Mongoose 7+
-  // but are harmless if included for compatibility
   await mongoose.connect(uri);
 });
 


### PR DESCRIPTION
## Summary

Fixes #630

The backend test step in CI was swallowing failures with `|| true`, meaning broken tests could be merged into main with a green check. This PR removes the workaround and fixes the underlying test issues that originally caused it to be added.

## Changes

### .github/workflows/ci.yml
- Removed `|| true` from the "Run server tests" step so `npm test` exit code is respected

### server/routes/cart.js
- Added `module.exports.adjustReserved = adjustReserved;` to export the function for testing (the cart.reserved.test.js was failing because it couldn't import `adjustReserved`)

### server/tests/cart.reserved.test.js
- Removed hardcoded Windows path (`C:\Program Files\MongoDB\Server\8.0\bin\mongod.exe`) that would fail on CI's Ubuntu runner
- `mongodb-memory-server` will auto-download the appropriate binary for the platform

## Why These Changes Fix the Root Cause
The `|| true` was originally added because tests were failing in CI due to:
1. `adjustReserved` not being exported (import error crashes the test suite)
2. Hardcoded Windows binary path failing on Ubuntu

With both fixed, the tests can pass honestly and the exit code can be trusted.

Closes #630
