### PR TITLE
feat: Wire debounced search to server-side filtering via useInfiniteProducts

### DIFF
--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -213,7 +213,7 @@ export default function HomePage() {
     return () => unsub();
   }, [navigate]);
 
-  // React Query: infinite products
+  // React Query: infinite products — pass debounced search + category for server-side filtering
   const {
     data: pagesData,
     isLoading: rqLoading,
@@ -221,7 +221,11 @@ export default function HomePage() {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
-  } = useInfiniteProducts({ limit: 24 });
+  } = useInfiniteProducts({
+    limit: 24,
+    search: debouncedQuery || undefined,
+    category: activeCategory !== "all" ? activeCategory : undefined,
+  });
 
   useEffect(() => {
     setLoading(rqLoading);
@@ -329,6 +333,8 @@ export default function HomePage() {
   const firstName = user?.displayName?.split(" ")[0] || "there";
 
   const filtered = products.filter(p => {
+    // Server-side filtering handles category + search via useInfiniteProducts params.
+    // This client-side filter is a safety fallback for any edge cases.
     const matchCat = activeCategory === "all" || p.category === activeCategory;
     const matchSearch = !debouncedQuery
       || p.name.toLowerCase().includes(debouncedQuery.toLowerCase())


### PR DESCRIPTION
## Summary

Fixes #584

Wires the existing debounced search query and active category to `useInfiniteProducts` so product filtering happens server-side instead of fetching all products and filtering in the browser.

## Problem

Previously, `HomePage.jsx` called `useInfiniteProducts({ limit: 24 })` without passing search or category parameters. It fetched all products upfront and did client-side filtering with `debouncedQuery`. While there was already a 300ms debounce preventing per-keystroke re-renders, the actual API call always requested ALL products regardless of what the user searched for.

## Fix

```javascript
// Before
useInfiniteProducts({ limit: 24 });

// After
useInfiniteProducts({
  limit: 24,
  search: debouncedQuery || undefined,
  category: activeCategory !== "all" ? activeCategory : undefined,
});
```

The `useInfiniteProducts` hook already supported `search` and `category` params (passing them as URL query strings to `GET /api/products`). This change simply connects them to the UI state.

## Benefits
- Reduced network payload: only matching products are returned from the server
- Reduced backend load: DB query filters at the database level
- No per-keystroke API calls: the existing 300ms debounce ensures requests fire only after typing pauses
- React Query handles caching and deduplication, so repeated searches are instant
- Client-side filter kept as a fallback for any edge cases

## No Breaking Changes
- Existing search UX is preserved (same debounce delay, same UI)
- Category pill behavior unchanged
- Pagination/infinite scroll still works
- The `useInfiniteProducts` hook API is unchanged

Closes #584
