### PR TITLE
refactor: Remove leftover debug console.log from ExercisePage

### DIFF
--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -60,19 +60,6 @@ export default function ExercisePage() {
 
       const data = await response.json();
 
-      // Client-side debug logging
-      if (data && data.length > 0) {
-        const firstEx = data[0];
-        console.log(`\n[Exercise Client] Received ${data.length} exercises for "${bodyPart}"`);
-        console.log("  First exercise name:", firstEx.name);
-        console.log("  First exercise gifUrl:", firstEx.gifUrl ? `✅ Present` : "❌ null");
-        console.log("  First exercise imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-        if (firstEx.gifUrl) {
-          console.log("  GIF URL preview:", firstEx.gifUrl.substring(0, 100));
-        }
-        console.log("");
-      }
-
       setExercises(data || []);
     } catch (err) {
       setError(err.message || "Failed to load exercises. Please try again.");


### PR DESCRIPTION
## Summary

Fixes #579

Removed 8 debug console.log statements from the etchExercises function in client/src/pages/ExercisePage.jsx (lines 66-73). These were development artifacts logging exercise data, gifUrl presence, and imageUrl presence to the browser console.

## What was removed
- Log of exercise count and body part name
- Log of first exercise name
- Log of gifUrl presence check
- Log of imageUrl presence check
- Log of gifUrl preview string
- Empty line spacer logs

## What was kept
- console.error for actual fetch failures (legitimate error logging)

## No functional changes
The ExercisePage behavior is completely unchanged. Only console noise in production is eliminated.

Closes #579