### PR TITLE
fix(auth): Remove hardcoded admin UID fallback from frontend bundle

### DIFF
--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
+const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || '';
 const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
 const DEV_ADMIN_EMAIL = import.meta.env.VITE_DEV_ADMIN_EMAIL || '';
 

--- a/client/src/components/NonAdminRoute.jsx
+++ b/client/src/components/NonAdminRoute.jsx
@@ -3,7 +3,7 @@ import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 import ReportBugButton from "./ReportBugButton";
 
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
+const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || '';
 const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
 
 export default function NonAdminRoute({ children }) {


### PR DESCRIPTION
## Summary

Fixes #650

Removes the hardcoded admin UID (
5LtrXIGVSVjNktRn1PgDXZbHgq1) from the frontend bundle. Previously, anyone could inspect the production JS and see the admin identifier.

## Changes

- **client/src/components/AdminRoute.jsx** — Changed fallback from hardcoded UID to empty string
- **client/src/components/NonAdminRoute.jsx** — Same fix

### Before
`javascript
const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || 'n5LtrXIGVSVjNktRn1PgDXZbHgq1';
`

### After
`javascript
const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || '';
`

## Security Note

The frontend admin check is only for routing/UX (redirecting admin users to the admin dashboard). Actual authorization is enforced server-side by the erifyAdmin middleware on all admin API routes. Removing this hardcoded UID does not break any functionality — it just requires the env var to be properly set.

## Setup Requirement

Ensure VITE_ADMIN_UID is set in your .env file for admin routing to work. The .env.example already documents this variable.

Closes #650