### PR TITLE
refactor: remove debug console logs from ExercisePage

### DIFF
--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -60,19 +60,6 @@ export default function ExercisePage() {
 
       const data = await response.json();
 
-      // Client-side debug logging
-      if (data && data.length > 0) {
-        const firstEx = data[0];
-        console.log(`\n[Exercise Client] Received ${data.length} exercises for "${bodyPart}"`);
-        console.log("  First exercise name:", firstEx.name);
-        console.log("  First exercise gifUrl:", firstEx.gifUrl ? `✅ Present` : "❌ null");
-        console.log("  First exercise imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-        if (firstEx.gifUrl) {
-          console.log("  GIF URL preview:", firstEx.gifUrl.substring(0, 100));
-        }
-        console.log("");
-      }
-
       setExercises(data || []);
     } catch (err) {
       setError(err.message || "Failed to load exercises. Please try again.");


### PR DESCRIPTION
## 📋 What does this PR do?

- Removed leftover debug `console.log()` statements from `client/src/pages/ExercisePage.jsx`.
- No functional changes were made.
- Existing error handling (`console.error`) remains unchanged.

## 🔗 Related Issue

Closes #579

## 🧪 How was this tested?

- Removed the debug logging block from the `fetchExercises` function.
- Verified that the Exercise page continues to fetch and display exercises correctly.
- Confirmed that the removed debug logs no longer appear in the browser console.

## 📸 Screenshots (if UI changes)

N/A (No UI changes)

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys