### PR TITLE
feat: add /health readiness endpoint with MongoDB connection check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
     networks:
       - fitmart-network
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:5000/"]
+      test: ["CMD", "wget", "-qO-", "http://localhost:5000/health"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 // server/index.js
 require("dotenv").config();
+const mongoose = require("mongoose");
 const rewardsRoutes = require("./routes/rewards");
 const express = require("express");
 const cors = require("cors");
@@ -182,8 +183,28 @@ if (process.env.NODE_ENV !== 'production') {
 // Proxy GitHub stats to avoid client-side rate limits and CORS errors
 app.use("/api/github", require("./routes/github"));
 
-// ── Health check ─────────────────────────────────────────────────────────────
-app.get("/", (req, res) => res.send("FitMart server running"));
+// Legacy root — redirect to /health for backwards compatibility
+app.get("/", (req, res) => {
+  res.redirect(307, "/health");
+});
+
+// ── Health / readiness check ───────────────────────────────────────────────────
+// Returns 200 when MongoDB is connected, 503 when unavailable.
+// Used by Docker healthcheck and external uptime monitors.
+app.get("/health", (req, res) => {
+  const dbState = mongoose.connection.readyState;
+  // readyState: 0=disconnected, 1=connected, 2=connecting, 3=disconnecting
+  const dbStatus = ["disconnected", "connected", "connecting", "disconnecting"][dbState] || "unknown";
+  const healthy = dbState === 1;
+
+  const payload = {
+    status: healthy ? "ok" : "unavailable",
+    db: dbStatus,
+    timestamp: new Date().toISOString(),
+  };
+
+  res.status(healthy ? 200 : 503).json(payload);
+});
 
 // ── Global error handler ─────────────────────────────────────────────────────
 app.use((err, req, res, next) => {


### PR DESCRIPTION
Closes #725

**Changes:**
- **server/index.js** — Replaced plain-text `"FitMart server running"` root route with a JSON `GET /health` endpoint that checks `mongoose.connection.readyState`:
  - Returns **200** `{ status: "ok", db: "connected", timestamp }` when MongoDB is connected
  - Returns **503** `{ status: "unavailable", db: "...", timestamp }` when DB is disconnected/connecting/disconnecting
  - Root `/` kept as a **307 redirect** to `/health` for backwards compatibility
- **docker-compose.yml** — Updated server healthcheck from `http://localhost:5000/` → `http://localhost:5000/health`

**Why this matters:**
Docker and future orchestrators (Kubernetes, etc.) can now distinguish between "process is alive" and "the API can actually serve requests." If MongoDB goes down, the container reports unhealthy instead of masking the outage.