### PR TITLE
fix: prevent cart race condition and add fetch timeouts

### DIFF
--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -24,6 +24,19 @@ import CategoryPillsSkeleton from "../components/CategoryPillsSkeleton";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
+const CART_FETCH_TIMEOUT_MS = 15000;
+
+async function fetchWithTimeout(url, options, timeoutMs = CART_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal });
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 const CATEGORIES = [
   { name: "All", value: "all" },
   { name: "Equipment", value: "Equipment" },
@@ -187,6 +200,9 @@ export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
   const debounceRef = useRef(null);
+  const cartLoadRef = useRef(0);
+  const cartVersionRef = useRef(0);
+
   const [menuOpen, setMenuOpen] = useState(false);
   const [visible, setVisible] = useState(false);
   const [products, setProducts] = useState([]);
@@ -242,11 +258,14 @@ export default function HomePage() {
     if (!user || !products.length) return;
     (async () => {
       try {
+        const loadId = ++cartLoadRef.current;
         const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/cart/${user.uid}`, { headers, credentials: "include" });
+        const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}`, { headers, credentials: "include" });
         if (!res.ok) return;
         const cartDoc = await res.json();
-        setCart(mapCart(cartDoc, products));
+        if (loadId > cartVersionRef.current) {
+          setCart(mapCart(cartDoc, products));
+        }
       } catch (err) {
         console.error("Error loading cart:", err);
       }
@@ -265,8 +284,9 @@ export default function HomePage() {
   const addToCart = async (product) => {
     if (!user) return;
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/add`, {
+      const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}/add`, {
         method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: product.productId || product.id, quantity: 1 }),
       });
@@ -285,9 +305,10 @@ export default function HomePage() {
   const removeFromCart = async (id) => {
     if (!user) return;
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const existing = cart.find(i => i.id === id);
       const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
+      const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}/remove`, {
         method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
       });
@@ -306,9 +327,10 @@ export default function HomePage() {
   const updateQty = async (id, delta) => {
     if (!user) return;
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const url = delta > 0 ? "add" : "remove";
       const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/${url}`, {
+      const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}/${url}`, {
         method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
       });

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -15,9 +15,22 @@ const FEATURE_MAP = {
   Wearables: ["1-year warranty", "Water resistant", "Free shipping", "Returns within 15 days"],
 };
 
+const CART_FETCH_TIMEOUT_MS = 15000;
+
+async function fetchWithTimeout(url, options, timeoutMs = CART_FETCH_TIMEOUT_MS) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...options, signal: controller.signal });
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 async function apiAddToCart(userId, productId, quantity) {
   const headers = await getAuthHeaders();
-  const res = await fetch(`${API}/api/cart/${userId}/add`, {
+  const res = await fetchWithTimeout(`${API}/api/cart/${userId}/add`, {
     method: "POST", headers, credentials: "include",
     body: JSON.stringify({ productId, quantity }),
   });
@@ -30,7 +43,7 @@ async function apiAddToCart(userId, productId, quantity) {
 
 async function apiGetCart(userId) {
   const headers = await getAuthHeaders();
-  const res = await fetch(`${API}/api/cart/${userId}`, { headers, credentials: "include" });
+  const res = await fetchWithTimeout(`${API}/api/cart/${userId}`, { headers, credentials: "include" });
   if (!res.ok) throw new Error("Failed to fetch cart");
   return res.json();
 }
@@ -66,6 +79,8 @@ export default function ProductPage() {
 
   const imgRef = useRef(null);
   const stickyRef = useRef(null);
+  const cartLoadRef = useRef(0); // monotonic counter to prevent stale cart overwrites
+  const cartVersionRef = useRef(0);
 
   const cartCount = cart.reduce((sum, i) => sum + i.qty, 0);
   const cartTotal = cart.reduce((sum, i) => sum + i.price * i.qty, 0);
@@ -115,8 +130,13 @@ export default function ProductPage() {
         );
         const user = auth.currentUser;
         if (user) {
+          const loadId = ++cartLoadRef.current;
           const cartDoc = await apiGetCart(user.uid);
-          setCart(enrichCart(cartDoc, normalised));
+          // Only apply initial cart data if the user hasn't modified the cart
+          // since this load started (prevents stale overwrites from race conditions)
+          if (loadId > cartVersionRef.current) {
+            setCart(enrichCart(cartDoc, normalised));
+          }
         }
       } catch (err) {
         setError(err.message);
@@ -136,6 +156,7 @@ export default function ProductPage() {
     if (!user) { navigate("/auth"); return; }
     setAdding(true);
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const cartDoc = await apiAddToCart(user.uid, product.productId, quantity);
       setCart(enrichCart(cartDoc, products));
       setAdded(true);
@@ -153,6 +174,7 @@ export default function ProductPage() {
     if (!user) { navigate("/auth"); return; }
     setBuyingNow(true);
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       await apiAddToCart(user.uid, product.productId, quantity);
       navigate("/checkout");
     } catch (err) {
@@ -166,9 +188,10 @@ export default function ProductPage() {
     const user = auth.currentUser;
     if (!user) return;
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const existing = cart.find(i => i.id === id);
       const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/remove`, {
+      const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}/remove`, {
         method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: existing?.qty || 1 }),
       });
@@ -188,9 +211,10 @@ export default function ProductPage() {
     const user = auth.currentUser;
     if (!user) return;
     try {
+      cartVersionRef.current = ++cartLoadRef.current;
       const url = delta > 0 ? "add" : "remove";
       const headers = await getAuthHeaders();
-      const res = await fetch(`${API}/api/cart/${user.uid}/${url}`, {
+      const res = await fetchWithTimeout(`${API}/api/cart/${user.uid}/${url}`, {
         method: "POST", headers, credentials: "include",
         body: JSON.stringify({ productId: id, quantity: Math.abs(delta) }),
       });


### PR DESCRIPTION
## Description

Fixes the "Add to Cart" bug where clicking the button produces no visible result and the cart remains empty.

**Root cause:** A race condition on the product detail page (and home page). The initial `useEffect` fetches the cart asynchronously on mount. If the user clicks "Add to Cart" before this initial GET completes, the server successfully processes the POST (adding the item), but then the stale GET response overwrites the client cart state with the old empty data — making the newly added item disappear.

## Changes

### `client/src/pages/ProductPage.jsx`
- Added `fetchWithTimeout()` — wraps `fetch` with an `AbortController` (15s timeout) for all cart API calls
- Added `cartLoadRef` / `cartVersionRef` monotonic counter refs for tracking cart data freshness
- Initial cart GET now captures a `loadId` snapshot and only applies the result if `loadId > cartVersionRef.current` (i.e., no user mutation happened since the load started)
- `handleAddToCart`, `handleBuyNow`, `removeFromCart`, `updateQty` bump `cartVersionRef` to invalidate any in-flight stale loads

### `client/src/pages/HomePage.jsx`
- Same `fetchWithTimeout()`, versioning refs, and race condition guard applied

## Why this works

The monotonic counter pattern:
- Initial load: `const loadId = ++cartLoadRef.current` (captures snapshot)
- User mutation: `cartVersionRef.current = ++cartLoadRef.current` (bumps version above all prior loads)
- Guard: `if (loadId > cartVersionRef.current)` — if loadId <= cartVersionRef, a user mutation has occurred since this load started, so discard the stale data

Closes #733