### PR TITLE
feat: add Razorpay webhook handler for reliable payment confirmation

### DIFF
--- a/docs/RAZORPAY_WEBHOOK_SETUP.md
+++ b/docs/RAZORPAY_WEBHOOK_SETUP.md
@@ -1,0 +1,62 @@
+# Razorpay Webhook Setup
+
+The FitMart server includes a webhook endpoint that reliably processes successful payments even if the client browser closes or the user navigates away before the client-side `verify-payment` callback completes.
+
+## Webhook URL
+
+Configure your Razorpay Dashboard to send the `payment.captured` event to:
+
+```
+https://your-domain.com/api/payment/webhook
+```
+
+For local development with ngrok:
+
+```
+https://your-ngrok-subdomain.ngrok-free.app/api/payment/webhook
+```
+
+> **Note:** Only the `payment.captured` event is processed. Other events (including `order.paid`) are acknowledged with `200` but ignored for order creation. This avoids a race condition where `order.paid` may fire without a `payment_id`.
+
+## Environment Variable
+
+Add the following to your `server/.env` file:
+
+```env
+RAZORPAY_WEBHOOK_SECRET=your_webhook_secret_here
+```
+
+The webhook secret is generated in the Razorpay Dashboard when you create a webhook. It is **not** the same as `RAZORPAY_KEY_SECRET`.
+
+## Razorpay Dashboard Configuration
+
+1. Go to the [Razorpay Dashboard](https://dashboard.razorpay.com/) → **Settings** → **Webhooks**
+2. Click **Add New Webhook**
+3. Enter the webhook URL (see above)
+4. Set the secret (this becomes `RAZORPAY_WEBHOOK_SECRET`)
+5. Select the following event:
+   - **`payment.captured`** — fires when a payment is successfully captured
+6. Save the webhook
+
+## How It Works
+
+1. When the server creates a Razorpay order (`POST /api/payment/create-order`), it includes `notes: { userId }` in the order payload.
+2. When Razorpay captures the payment, it sends a `payment.captured` webhook event to `/api/payment/webhook`.
+3. The server verifies the `x-razorpay-signature` header using HMAC-SHA256 with `RAZORPAY_WEBHOOK_SECRET`.
+4. The server extracts the `userId` from `payload.payment.entity.notes.userId`.
+5. If no order exists for this `paymentId` yet, the server creates the order from the user's cart, marks it as paid, awards FitRewards points, and sends the first-purchase email.
+6. If the order was already created by the client-side `verify-payment` callback, the webhook detects the duplicate by `paymentId` and returns `200 "already_exists"` — the operation is idempotent.
+
+## Idempotency & Race Conditions
+
+- **Client callback arrives first, webhook arrives second:** The webhook finds the existing order by `paymentId` and returns `200 "already_exists"`. No duplicate order is created.
+- **Webhook arrives first, client callback arrives second:** The webhook creates the order. The client callback's duplicate check (`Order.findOne({ paymentId })`) catches it and returns `{ success: true, message: "Order already created" }`. No duplicate order is created.
+- **Cart was already cleared (e.g., by a concurrent request):** `createOrder()` throws `"Cart is empty"`. The webhook catches this and returns `200 "skipped"` to prevent Razorpay retries.
+
+## Verifying the Setup
+
+1. Set `RAZORPAY_WEBHOOK_SECRET` in your environment
+2. Restart the server — check the startup logs for the optional env var warning (it will mention `RAZORPAY_WEBHOOK_SECRET` if not set)
+3. Make a test payment using the FitMart checkout flow
+4. Check the server logs for: `Webhook received: payment.captured`
+5. Verify the order appears in the database with `status: "paid"` and the correct `paymentId`

--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,7 @@ const CRITICAL_ENV_VARS = ["MONGO_URI"];
 const OPTIONAL_ENV_VARS = [
   "RAZORPAY_KEY_ID",
   "RAZORPAY_KEY_SECRET",
+  "RAZORPAY_WEBHOOK_SECRET",
   "MONGO_DB",
   "PORT",
   "FIREBASE_PROJECT_ID",
@@ -106,6 +107,11 @@ app.use(
 );
 
 app.use(helmet());
+
+// ── Razorpay webhook needs the raw request body for signature verification ──
+// Must be registered BEFORE express.json() so the body isn't consumed by JSON parser
+app.use('/api/payment/webhook', express.raw({ type: 'application/json' }));
+
 app.use(express.json({ limit: "10kb" }));
 app.use(express.urlencoded({ extended: true, limit: "10kb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses

--- a/server/routes/payment.js
+++ b/server/routes/payment.js
@@ -57,6 +57,7 @@ router.post("/create-order", verifyFirebaseToken, async (req, res) => {
       amount: Math.round(amount * 100),   // ₹ → paise
       currency,
       receipt,
+      notes: { userId },                  // passed through to webhook events
     });
 
     res.json(order);
@@ -188,6 +189,157 @@ router.post("/clear-cart", verifyFirebaseToken, async (req, res) => {
   } catch (err) {
     console.error("clear-cart error:", err);
     res.status(500).json({ error: err.message });
+  }
+});
+
+/**
+ * @route   POST /webhook
+ * @desc    Razorpay webhook handler — verifies x-razorpay-signature header using the
+ *          raw request body, handles payment.captured / order.paid events idempotently.
+ *          If the client callback (verify-payment) never arrived, this ensures the order
+ *          is still created and recorded. req.body is a Buffer delivered by the
+ *          express.raw() middleware registered in server/index.js.
+ * @access  Public (authenticated by Razorpay HMAC signature)
+ */
+router.post('/webhook', async (req, res) => {
+  try {
+    const rawBody = req.body;                       // Buffer from express.raw()
+    const signature = req.headers['x-razorpay-signature'];
+
+    if (!signature) {
+      return res.status(400).json({ error: 'Missing x-razorpay-signature header' });
+    }
+
+    const webhookSecret = process.env.RAZORPAY_WEBHOOK_SECRET;
+    if (!webhookSecret) {
+      logger.error('RAZORPAY_WEBHOOK_SECRET is not configured — cannot verify webhooks');
+      return res.status(500).json({ error: 'Webhook secret not configured' });
+    }
+
+    // Verify HMAC-SHA256 signature against the raw body
+    const expectedSignature = crypto
+      .createHmac('sha256', webhookSecret)
+      .update(rawBody)
+      .digest('hex');
+
+    // Use timing-safe comparison to prevent timing attacks
+    const sigBuf = Buffer.from(expectedSignature);
+    const reqBuf = Buffer.from(signature);
+
+    if (sigBuf.length !== reqBuf.length || !crypto.timingSafeEqual(sigBuf, reqBuf)) {
+      logger.warn('Webhook signature mismatch — possible forgery attempt');
+      return res.status(400).json({ error: 'Invalid signature' });
+    }
+
+    // Parse the verified event payload
+    const event = JSON.parse(rawBody.toString());
+    const eventType = event.event;
+
+    logger.info(`Webhook received: ${eventType}`);
+
+    // ── Extract payment details based on event type ──────────────────────────
+    let paymentId = null;
+    let userId = null;
+
+    if (eventType === 'payment.captured') {
+      const payment = event.payload.payment.entity;
+      paymentId = payment.id;
+      userId = payment.notes?.userId;
+    } else {
+      // Acknowledge non-payment events (including order.paid) silently so Razorpay
+      // doesn't retry. We only create orders on payment.captured because it always
+      // carries paymentId + notes.userId, avoiding the race where order.paid fires
+      // first without a paymentId.
+      return res.status(200).json({ status: 'ignored' });
+    }
+
+    if (!userId) {
+      logger.warn(`Webhook ${eventType}: no userId in notes — order cannot be processed`);
+      return res.status(200).json({ status: 'ignored', reason: 'no userId in notes' });
+    }
+
+    // ── Idempotency check — prevent duplicate order creation ─────────────────
+    // If the client callback (verify-payment) already created the order with this
+    // paymentId, or a previous webhook delivery did, skip processing.
+    const Order = require('../models/Order');
+
+    if (paymentId) {
+      const existingOrder = await Order.findOne({ paymentId });
+      if (existingOrder) {
+        logger.info(`Webhook: order ${existingOrder._id} already exists for payment ${paymentId}`);
+        return res.status(200).json({ status: 'already_exists', orderId: existingOrder._id });
+      }
+    }
+
+    // ── Create the order from the user's cart ────────────────────────────────
+    let order;
+    try {
+      order = await createOrder(userId);
+    } catch (createErr) {
+      // Cart empty likely means verify-payment already ran and cleared it,
+      // or the user's session expired. Return 200 to avoid Razorpay retries.
+      logger.warn(`Webhook: createOrder failed for ${userId}: ${createErr.message}`);
+      return res.status(200).json({ status: 'skipped', reason: createErr.message });
+    }
+
+    // Attach paymentId and mark the order as paid
+    const updateFields = { status: 'paid' };
+    if (paymentId) {
+      updateFields.paymentId = paymentId;
+    }
+    await Order.findByIdAndUpdate(order._id, updateFields);
+    Object.assign(order, updateFields);
+
+    // ── Award FitRewards loyalty points ───────────────────────────────────────
+    try {
+      let rewards = await Rewards.findOne({ userId });
+      if (!rewards) {
+        rewards = await Rewards.create({
+          userId,
+          pointsBalance: 0,
+          transactions: [],
+        });
+      }
+
+      const alreadyCredited = rewards.transactions.some(
+        (t) => t.orderId === String(order._id),
+      );
+
+      if (!alreadyCredited) {
+        const purchaseAmount = order.totalAmount || order.total || order.amount || 0;
+        let points = Math.floor(Number(purchaseAmount) * rewardsConfig.POINTS_PER_RUPEE);
+
+        if (rewards.transactions.length === 0) {
+          points += rewardsConfig.FIRST_PURCHASE_BONUS;
+        }
+
+        rewards.transactions.push({
+          type: 'earned',
+          points,
+          source: 'purchase',
+          orderId: String(order._id),
+          description: 'Points earned from purchase',
+          createdAt: new Date(),
+        });
+
+        rewards.pointsBalance += points;
+        await rewards.save();
+      }
+    } catch (rewardError) {
+      logger.error('Webhook reward earning failed:', rewardError.message);
+    }
+
+    // ── Send first-purchase email (non-blocking) ─────────────────────────────
+    sendFirstPurchaseEmail(userId, order).catch((err) => {
+      logger.error('Webhook first-purchase email error:', err.message);
+    });
+
+    res.status(200).json({ status: 'ok', orderId: order._id });
+  } catch (err) {
+    logger.error('Webhook error:', err);
+    // Return 200 even on unexpected errors to prevent Razorpay from retrying
+    // for internal processing failures that will not succeed on retry.
+    res.status(200).json({ status: 'error', reason: err.message });
   }
 });
 


### PR DESCRIPTION
## Description

Adds a `POST /api/payment/webhook` endpoint that verifies Razorpay's `x-razorpay-signature` header and handles `payment.captured` events idempotently.

**Problem:** Payment confirmation relied solely on the client-driven verify-payment callback. If the browser closes or the network drops after payment but before the callback, the payment succeeds at Razorpay while FitMart never records the order.

**Solution:**
- New `POST /api/payment/webhook` endpoint with HMAC-SHA256 signature verification via `crypto.timingSafeEqual`
- `express.raw()` middleware registered **before** the global `express.json()` so the raw request body is available for signature verification
- `notes: { userId }` passed when creating Razorpay orders so the webhook can identify the user
- Handles `payment.captured` events: creates order, attaches paymentId, marks as paid, awards FitRewards points, sends first-purchase email
- Idempotent — checks by `paymentId` before creating an order
- Returns 200 on business-logic errors (e.g. empty cart) to prevent Razorpay retries
- New `docs/RAZORPAY_WEBHOOK_SETUP.md` with Razorpay dashboard configuration instructions
- `RAZORPAY_WEBHOOK_SECRET` added to startup env var log

## Related Issue
Closes #741