### PR TITLE
Fix cart drawer overlapping header on shopping page

### DIFF
--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -34,13 +34,13 @@ function CartDrawer({
     <>
       {/* Overlay */}
       <div
-        className={`overlay fixed inset-0 bg-black/30 z-50 ${isOpen ? "show" : ""}`}
+        className={`overlay fixed inset-x-0 bottom-0 top-14 sm:top-16 bg-black/30 z-50 ${isOpen ? "show" : ""}`}
         onClick={onClose}
       />
 
       {/* Drawer — full-width on mobile, max-sm on larger screens */}
       <aside
-        className={`cart-slide fixed right-0 top-0 h-full z-50 shadow-2xl flex flex-col
+        className={`cart-slide fixed right-0 top-14 sm:top-16 h-[calc(100vh-3.5rem)] sm:h-[calc(100vh-4rem)] z-50 shadow-2xl flex flex-col
                     bg-white w-full sm:max-w-sm ${isOpen ? "open" : ""}`}
       >
         {/* ── Header ── */}


### PR DESCRIPTION
## 📋 What does this PR do?

The cart drawer was rendered with `top-0 h-full`, causing it to start at the very top of the viewport and slide over the navbar instead of below it. This PR offsets the drawer and its backdrop overlay downward by the exact height of the navbar so the header stays fully visible and accessible when the cart is open.

## 🔗 Related Issue

Closes #736

## 🧪 How was this tested?

- Opened the Shopping page and clicked the cart icon
- Verified the header (FitMart logo + nav icons) remains visible above the drawer
- Verified the drawer fills the remaining viewport below the header with no gap
- Tested on both mobile (< 640px) and desktop (≥ 640px) breakpoints
- Closed the drawer and verified no layout regressions on other pages

## 📸 Screenshots (if UI changes)

| Before | After |
|--------|-------|
| Drawer covers header — navbar hidden | Header visible, drawer starts below navbar |

## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
