### PR TITLE
Fix cart drawer overlapping header on shopping page

### DIFF
--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -11,6 +11,7 @@ function CartDrawer({
   cartTotal,
   updateQty,
   removeFromCart,
+  topOffset = "0px",
 }) {
   useEffect(() => {
     const handleKeyDown = (e) => {
@@ -34,13 +35,20 @@ function CartDrawer({
     <>
       {/* Overlay */}
       <div
-        className={`overlay fixed inset-0 bg-black/30 z-50 ${isOpen ? "show" : ""}`}
+        className={`overlay fixed left-0 right-0 bottom-0 bg-black/30 z-50 ${
+          isOpen ? "show" : ""
+        }`}
+        style={{ top: topOffset }}
         onClick={onClose}
       />
 
       {/* Drawer — full-width on mobile, max-sm on larger screens */}
       <aside
-        className={`cart-slide fixed right-0 top-0 h-full z-50 shadow-2xl flex flex-col
+        style={{
+          top: topOffset,
+          height: `calc(100vh - ${topOffset})`,
+        }}
+        className={`cart-slide fixed right-0 z-50 shadow-2xl flex flex-col
                     bg-white w-full sm:max-w-sm ${isOpen ? "open" : ""}`}
       >
         {/* ── Header ── */}

--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -681,10 +681,15 @@ export default function HomePage() {
       </footer>
 
       <CartDrawer
-        isOpen={cartOpen} onClose={() => setCartOpen(false)}
-        cart={cart} cartCount={cartCount} cartTotal={cartTotal}
-        updateQty={updateQty} removeFromCart={removeFromCart}
-      />
+        isOpen={cartOpen}
+        onClose={() => setCartOpen(false)}
+        cart={cart}
+        cartCount={cartCount}
+        cartTotal={cartTotal}
+        updateQty={updateQty}
+        removeFromCart={removeFromCart}
+        topOffset="80px"
+    />
       <ErrorBoundary fallback={
         <div className="fixed bottom-6 right-6 z-50 bg-white border border-stone-200 rounded-2xl p-4 shadow-lg max-w-xs">
           <p className="text-xs tracking-[0.15em] uppercase text-stone-400 mb-1">Assistant</p>


### PR DESCRIPTION
## 📋 What does this PR do?

Fixes the cart drawer overlapping the fixed header on the Shopping page by introducing a configurable top offset for the CartDrawer component. The drawer and overlay now respect the header height while preserving the existing behavior on other pages.

## 🔗 Related Issue

Closes #736

## 🧪 How was this tested?

- Ran the application locally.
- Opened the Shopping page.
- Verified the cart drawer opens below the header.
- Confirmed the header remains visible and accessible.
- Checked that the cart drawer behavior on other pages is unchanged.



## ✅ Checklist

- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys