### PR TITLE
chore: add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,69 @@
+---
+name: 🐛 Bug Report
+about: Report a bug to help us improve FitMart
+title: "[Bug] "
+labels: bug
+assignees: ""
+
+---
+
+## 🐛 Description
+
+A clear and concise description of what the bug is.
+
+---
+
+## 🔄 Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+---
+
+## ✅ Expected Behavior
+
+What you expected to happen instead.
+
+---
+
+## ❌ Actual Behavior
+
+What actually happened. Include error messages, crash logs, or unexpected UI states.
+
+---
+
+## 📸 Screenshots / Screen Recording
+
+If applicable, add screenshots or a screen recording to help explain the problem.
+
+---
+
+## 🌐 Environment
+
+- **OS:** (e.g., Windows 11, macOS 14, Ubuntu 22.04)
+- **Browser:** (e.g., Chrome 120, Firefox 121, Safari 17)
+- **Node.js version:** (e.g., 20.11.0)
+- **Server commit / branch:** (e.g., `main` at `abc1234`)
+- **Client commit / branch:** (e.g., `main` at `def5678`)
+
+---
+
+## 📋 Additional Context
+
+Add any other context about the problem here (e.g., related issues, logs, configuration).
+
+---
+
+## 🧪 Can you reproduce it?
+
+- [ ] Yes, I can reliably reproduce this bug
+- [ ] Sometimes, it's intermittent
+- [ ] No, I couldn't reproduce it
+
+## 📦 Does this happen on the live site?
+
+- [ ] Yes, on the deployed version
+- [ ] No, only locally
+- [ ] I haven't checked

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 Community Discussion
+    url: https://github.com/parthbuilds-community/FitMart/discussions
+    about: Ask questions, share ideas, or discuss the project with the community.
+  - name: 🔒 Security Issue
+    url: https://github.com/parthbuilds-community/FitMart/security/policy
+    about: Report security vulnerabilities confidentially — do not open a public issue.
+  - name: 📖 Documentation
+    url: https://github.com/parthbuilds-community/FitMart/blob/main/docs/CONTRIBUTING.md
+    about: Check the contributing guide before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,59 @@
+---
+name: ✨ Feature Request
+about: Suggest an idea or improvement for FitMart
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+
+---
+
+## ✨ Feature Description
+
+A clear and concise description of the feature or improvement you'd like.
+
+---
+
+## 🎯 Problem Statement
+
+What problem does this feature solve? Describe the pain point or limitation you're experiencing.
+
+---
+
+## 💡 Proposed Solution
+
+Describe how you envision this feature working. Be as specific as possible — include UI mockups, API design ideas, or code sketches if helpful.
+
+---
+
+## 🔄 Alternative Approaches
+
+Is there another way to solve this problem? What alternatives have you considered?
+
+---
+
+## 📸 Mockups / Examples
+
+If applicable, add mockups, screenshots from other apps, or links to similar features that demonstrate the idea.
+
+---
+
+## 📋 Additional Context
+
+Add any other context, references, or related issues here.
+
+---
+
+## 🤔 Would you be willing to work on this?
+
+- [ ] Yes, I'd like to implement this feature
+- [ ] I'd need some guidance to get started
+- [ ] No, I'm just suggesting the idea
+
+## 🏷️ Type of change
+
+- [ ] New feature or component
+- [ ] Improvement to existing feature
+- [ ] UI/UX enhancement
+- [ ] Performance optimization
+- [ ] Documentation
+- [ ] Other (describe above)


### PR DESCRIPTION
## 📋 What does this PR do?

Adds structured GitHub issue templates to replace the current free-form issue creation, ensuring consistent bug reports and feature requests from contributors.

## 🔗 Related Issue

Closes #750

## 🧪 What was added?

- **`.github/ISSUE_TEMPLATE/bug_report.md`** — Bug report template with fields for description, steps to reproduce, expected/actual behavior, environment info, screenshots, and reproducibility checkboxes
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — Feature request template with fields for feature description, problem statement, proposed solution, alternatives, mockups, and willingness-to-implement checkboxes
- **`.github/ISSUE_TEMPLATE/config.yml`** — Config enabling blank issues and linking to Community Discussions, Security policy, and Contributing guide

All templates match the existing PR template style (emoji headers, markdown checklists, clean structure).