### PR TITLE
Return 404 when deleting a non-existent product

### DIFF
--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -204,9 +204,18 @@ router.delete('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   if (isNaN(productId)) {
     return res.status(400).json({ error: 'Invalid product ID. It must be a number.' });
   }
+
   try {
     const deleted = await Product.findOneAndDelete({ productId });
-    try { await cache.delPattern('products:'); } catch (e) { }
+
+    if (!deleted) {
+      return res.status(404).json({ error: 'Product not found' });
+    }
+
+    try {
+      await cache.delPattern('products:');
+    } catch (e) {}
+
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: 'Server error' });


### PR DESCRIPTION
## Summary

This PR fixes the DELETE `/api/products/:id` endpoint so it returns a `404 Not Found` response when the requested product does not exist.

## Changes Made

* Added a check for the result of `Product.findOneAndDelete()`.
* Return `404` with `{ "error": "Product not found" }` when no matching product is found.
* Preserve the existing success response when a product is deleted successfully.

## Why

Previously, the endpoint always returned:

```json
{ "success": true }
```

even when no product was deleted. This made it impossible for clients to distinguish between a successful deletion and a request for a non-existent product.

## Testing

* Verified the delete handler logic returns `404` when `findOneAndDelete()` returns `null`.
* Confirmed that the normal success response remains unchanged when a product is deleted.
