### PR TITLE
fix: return 404 when deleting non-existent product

### DIFF
--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -206,6 +206,7 @@ router.delete('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   }
   try {
     const deleted = await Product.findOneAndDelete({ productId });
+    if (!deleted) return res.status(404).json({ error: 'Product not found' });
     try { await cache.delPattern('products:'); } catch (e) { }
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
Closes #760

**Problem:** `DELETE /api/products/:id` returned `200 { success: true }` even when the product didn't exist, silently doing nothing.

**Fix:** Check the result of `findOneAndDelete()` — if it's `null`, return `404 { error: "Product not found" }` instead. This mirrors the same pattern already used by the `PUT /api/products/:id` handler.

**Changes:**
- `server/routes/products.js` — Added `if (!deleted) return res.status(404).json({ error: 'Product not found' });` after the `findOneAndDelete()` call