### PR TITLE
fix:return 404 when deleting non-existent product

### DIFF
--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -206,6 +206,9 @@ router.delete('/:id', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   }
   try {
     const deleted = await Product.findOneAndDelete({ productId });
+    if(!deleted){
+      return res.status(404).json({error : 'Product not found'});
+    }
     try { await cache.delPattern('products:'); } catch (e) { }
     res.json({ success: true });
   } catch (err) {


### PR DESCRIPTION
📋 What does this PR do?
Updates the DELETE /api/products/:id route to properly handle requests for non-existent products.

Previously, Product.findOneAndDelete would return null if the product didn't exist, but the API still returned a 200 { success: true } response. This PR adds a check to see if the product was actually found and deleted. If not, it correctly returns a 404 { error: 'Product not found' } response, bringing this route in line with the existing PUT handler.

🔗 Related Issue
Closes #760

🧪 How was this tested?
Tested locally by sending a DELETE request to /api/products/fake-non-existent-id.

Verified that the server now correctly responds with a 404 status code and the "Product not found" error message, rather than silently failing and returning 200 OK.

Verified that deleting an existing product still works as expected and successfully clears the Redis cache.

📸 Screenshots (if UI changes)
N/A - Backend logic fix only.

✅ Checklist
[x] I've read the CONTRIBUTING guide

[x] My code follows the project's style guidelines

[x] I've tested my changes locally

[x] I've linked the related issue

[x] I haven't introduced any new secrets or API keys