### PR TITLE
Refactor: Validate process.env using Zod on server startup

### DIFF
--- a/server/config/envSchema.js
+++ b/server/config/envSchema.js
@@ -1,0 +1,80 @@
+// server/config/envSchema.js
+// Zod schema for validating all environment variables on server startup.
+// Critical (required) vars cause process.exit(1) if missing/invalid.
+// Optional vars are validated for type/format when present but won't block startup.
+
+const { z } = require("zod");
+
+const envSchema = z.object({
+  // ── Critical (required) ──────────────────────────────────────────────
+  MONGO_URI: z
+    .string()
+    .url("MONGO_URI must be a valid URL")
+    .min(1, "MONGO_URI is required"),
+
+  // ── Server config ────────────────────────────────────────────────────
+  PORT: z.coerce.number().int().positive().optional(),
+  NODE_ENV: z.enum(["production", "development", "test"]).optional(),
+  ALLOWED_ORIGIN: z.string().optional(),
+  ALLOW_ALL_ORIGINS: z
+    .union([z.literal("true"), z.literal("false")])
+    .optional(),
+
+  // ── Razorpay ─────────────────────────────────────────────────────────
+  RAZORPAY_KEY_ID: z.string().optional(),
+  RAZORPAY_KEY_SECRET: z.string().optional(),
+
+  // ── Database ─────────────────────────────────────────────────────────
+  MONGO_DB: z.string().optional(),
+
+  // ── Firebase Admin ───────────────────────────────────────────────────
+  FIREBASE_PROJECT_ID: z.string().optional(),
+  FIREBASE_CLIENT_EMAIL: z.string().email().optional(),
+  FIREBASE_PRIVATE_KEY: z.string().optional(),
+  GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
+
+  // ── SMTP / Email ────────────────────────────────────────────────────
+  SMTP_HOST: z.string().optional(),
+  SMTP_PORT: z.coerce.number().int().positive().optional(),
+  SMTP_USER: z.string().optional(),
+  SMTP_PASS: z.string().optional(),
+  SMTP_SECURE: z
+    .union([z.literal("true"), z.literal("false")])
+    .optional(),
+  SMTP_FROM: z.string().optional(),
+  APP_BASE_URL: z.string().url().optional(),
+
+  // ── Redis / Cache ───────────────────────────────────────────────────
+  UPSTASH_REDIS_REST_URL: z.string().url().optional(),
+  UPSTASH_REDIS_REST_TOKEN: z.string().optional(),
+  REDIS_URL: z.string().url().optional(),
+  REDIS_HOST: z.string().optional(),
+  PRODUCTS_CACHE_TTL: z.coerce.number().int().positive().optional(),
+  DEBUG_REDIS: z
+    .union([z.literal("true"), z.literal("false")])
+    .optional(),
+
+  // ── Gemini / AI ─────────────────────────────────────────────────────
+  GEMINI_API_KEY: z.string().optional(),
+  GEMINI_MODEL_NAME: z.string().optional(),
+
+  // ── Admin / Auth ────────────────────────────────────────────────────
+  ADMIN_UID: z.string().optional(),
+  SUPER_ADMIN_UID: z.string().optional(),
+  VITE_ADMIN_UID: z.string().optional(),
+  VITE_SUPER_ADMIN_UID: z.string().optional(),
+  DEV_ADMIN_UID: z.string().optional(),
+  DEV_ADMIN_EMAIL: z.string().email().optional(),
+
+  // ── Cloudinary ──────────────────────────────────────────────────────
+  CLOUDINARY_CLOUD_NAME: z.string().optional(),
+  CLOUDINARY_API_KEY: z.string().optional(),
+  CLOUDINARY_API_SECRET: z.string().optional(),
+
+  // ── Other ───────────────────────────────────────────────────────────
+  RAPIDAPI_KEY: z.string().optional(),
+  RAPIDAPI_HOST: z.string().optional(),
+  GITHUB_TOKEN: z.string().optional(),
+});
+
+module.exports = envSchema;

--- a/server/index.js
+++ b/server/index.js
@@ -23,10 +23,28 @@ if (isDev) {
   allowedOrigins.push("http://localhost:5173", "http://127.0.0.1:5173");
 }
 
-// Display missing variables at server startup. Only require truly critical vars
-// to avoid failing entirely in environments where optional services (Razorpay)
-// are intentionally not configured (for example: demo deployments on Vercel).
-const CRITICAL_ENV_VARS = ["MONGO_URI"];
+// Validate environment variables with Zod on startup.
+// Critical vars (MONGO_URI) cause process.exit(1) if missing/invalid.
+// Optional vars that are missing are logged as warnings but don't block startup.
+const { ZodError } = require("zod");
+const envSchema = require("./config/envSchema");
+
+try {
+  envSchema.parse(process.env);
+} catch (err) {
+  if (err instanceof ZodError) {
+    console.error("❌ Invalid environment variables:");
+    for (const issue of err.issues) {
+      console.error(`   - ${issue.path.join(".")}: ${issue.message}`);
+    }
+    console.error(
+      "Server cannot start. Please fix the above issues in your environment.",
+    );
+    process.exit(1);
+  }
+  throw err;
+}
+
 const OPTIONAL_ENV_VARS = [
   "RAZORPAY_KEY_ID",
   "RAZORPAY_KEY_SECRET",
@@ -41,18 +59,7 @@ const OPTIONAL_ENV_VARS = [
   "SMTP_PASS",
 ];
 
-const missingCritical = CRITICAL_ENV_VARS.filter((v) => !process.env[v]);
 const missingOptional = OPTIONAL_ENV_VARS.filter((v) => !process.env[v]);
-
-if (missingCritical.length > 0) {
-  console.error(
-    `❌ Missing critical environment variables: ${missingCritical.join(", ")}`,
-  );
-  console.error(
-    "Server cannot start without these. Please set them in your environment.",
-  );
-  process.exit(1);
-}
 
 if (missingOptional.length > 0) {
   console.warn(


### PR DESCRIPTION
Closes #763

## Summary

Replaces the manual `CRITICAL_ENV_VARS` / `OPTIONAL_ENV_VARS` array filtering in `server/index.js` with a comprehensive Zod schema that validates types, formats, and presence of all environment variables at startup.

## Changes

**`server/config/envSchema.js`** — New file. A `z.object()` schema covering all 38 env vars used across the backend:
- **Critical:** `MONGO_URI` (required, validated as URL)
- **Server config:** `PORT` (coerced to positive int), `NODE_ENV` (enum), `ALLOWED_ORIGIN`, `ALLOW_ALL_ORIGINS` (true/false literal)
- **Payments:** Razorpay keys
- **Auth:** Firebase Admin credentials (`FIREBASE_CLIENT_EMAIL` validated as email)
- **Email:** SMTP host, port, user, pass, `SMTP_SECURE` (true/false), `APP_BASE_URL` (validated as URL)
- **Cache:** Upstash Redis URL/token, Redis URL/host, cache TTL, debug flag
- **AI:** Gemini API key, model name
- **Media:** Cloudinary credentials
- **Auth/Admin:** Admin UIDs, Dev admin email (validated as email)
- **Other:** RapidAPI key/host, GitHub token

All fields except `MONGO_URI` are `.optional()` — missing optional vars won't block startup, matching existing behavior.

**`server/index.js`** — Replaced the manual env var check block with `envSchema.parse(process.env)`. On `ZodError`, logs each issue's path and message, then `process.exit(1)`. Preserves the optional-var warning list as a separate diagnostic.

## Why

- Guarantees type safety for env vars across the entire backend
- Catches format errors (e.g., invalid URL, non-numeric PORT) before they cause cryptic runtime crashes
- Reuses the Zod pattern already established in `server/validation/requestSchemas.js` and `server/middleware/validateRequest.js`
- Single source of truth for all env var definitions