### PR TITLE
feat: implement global Scroll to Top Floating Action Button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import LegalTerms from "./pages/LegalTerms";
 import LegalPrivacy from "./pages/LegalPrivacy";
 import DevAdminLogin from "./components/DevAdminLogin";
+import ScrollToTopFAB from "./components/ScrollToTopFAB";
 
 export default function App() {
   const queryClient = new QueryClient();
@@ -36,6 +37,7 @@ export default function App() {
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <BrowserRouter>
+          <ScrollToTopFAB />
           <Routes>
             {/* Public routes (redirect admin users to admin dashboard) */}
             <Route path="/" element={<NonAdminRoute><LandingPage /></NonAdminRoute>} />

--- a/client/src/components/ScrollToTopFAB.jsx
+++ b/client/src/components/ScrollToTopFAB.jsx
@@ -1,0 +1,77 @@
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * ScrollToTopFAB — Floating Action Button that appears after scrolling
+ * past a threshold and smoothly scrolls back to the top on click.
+ *
+ * @param {Object} props
+ * @param {number} [props.threshold=500] - Scroll Y threshold to show the button
+ * @param {number} [props.size=44] - Button diameter in px
+ * @param {string} [props.position="bottom-6 right-6"] - Tailwind position classes
+ */
+export default function ScrollToTopFAB({
+  threshold = 500,
+  size = 44,
+  position = "bottom-6 right-6",
+}) {
+  const [visible, setVisible] = useState(false);
+
+  const handleScroll = useCallback(() => {
+    setVisible(window.scrollY > threshold);
+  }, [threshold]);
+
+  useEffect(() => {
+    // Check initial scroll position in case page loads mid-scroll
+    setVisible(window.scrollY > threshold);
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, [handleScroll, threshold]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  const sizeStyle = { width: size, height: size };
+
+  return (
+    <button
+      onClick={scrollToTop}
+      aria-label="Scroll to top"
+      tabIndex={visible ? 0 : -1}
+      style={sizeStyle}
+      className={`
+        fixed ${position} z-50
+        flex items-center justify-center
+        rounded-full bg-stone-900 text-white
+        shadow-lg shadow-stone-900/20
+        transition-all duration-300 ease-out
+        hover:bg-stone-800 hover:shadow-xl hover:shadow-stone-900/30
+        hover:-translate-y-0.5
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-400
+        focus-visible:ring-offset-2
+        active:scale-95
+        ${visible
+          ? "opacity-100 translate-y-0 pointer-events-auto"
+          : "opacity-0 translate-y-3 pointer-events-none"
+        }
+      `}
+    >
+      {/* Chevron-up icon */}
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+        style={{ width: size * 0.45, height: size * 0.45 }}
+      >
+        <path d="M18 15l-6-6-6 6" />
+      </svg>
+    </button>
+  );
+}


### PR DESCRIPTION
## Description

Implements a reusable `<ScrollToTopFAB />` component that improves navigation on long, content-heavy pages like HomePage and ProductPage.

### Changes

- **`client/src/components/ScrollToTopFAB.jsx`** — New component:
  - Hidden at the top; fades in (opacity + translate-y) at bottom-right after scrolling past 500px
  - Fixed z-50 positioning with smooth transitions (duration-300 ease-out)
  - Passive scroll listener with proper cleanup
  - Configurable `threshold`, `size`, and `position` props
  - Accessibility: `aria-label="Scroll to top"`, `tabIndex={-1}` when hidden, `focus-visible` ring
  - Hover lift effect, active press effect
  - Checks initial scroll Y on mount (handles page loads mid-scroll)
  - Chevron-up SVG icon scaled proportionally

- **`client/src/App.jsx`** — Imported and rendered `<ScrollToTopFAB />` globally inside `<BrowserRouter>`

### Why this is needed

Pages like HomePage (with multiple product categories) and ProductPage can get quite long on mobile. Users currently have to manually swipe all the way back up. This is a standard quality-of-life feature for modern web apps.

Closes #780