### PR TITLE
feat: implement global scroll to top floating action button

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -29,6 +29,7 @@ import ErrorBoundary from "./components/ErrorBoundary";
 import LegalTerms from "./pages/LegalTerms";
 import LegalPrivacy from "./pages/LegalPrivacy";
 import DevAdminLogin from "./components/DevAdminLogin";
+import ScrollToTopFAB from "./components/ScrollToTopFAB";
 
 export default function App() {
   const queryClient = new QueryClient();
@@ -119,6 +120,11 @@ export default function App() {
             {/* Redirect unknown routes to NotFound */}
             <Route path="*" element={<NotFound />} />
           </Routes>
+
+          {/* Global scroll-to-top button — rendered outside <Routes> so it
+              appears on every page (public, admin, auth, plans, 404) without
+              depending on NonAdminRoute/AdminRoute guards. */}
+          <ScrollToTopFAB />
         </BrowserRouter>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/client/src/components/ScrollToTopFAB.jsx
+++ b/client/src/components/ScrollToTopFAB.jsx
@@ -1,0 +1,51 @@
+// src/components/ScrollToTopFAB.jsx
+import { useState, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+const SHOW_AFTER_PX = 500;
+
+export default function ScrollToTopFAB() {
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        const onScroll = () => {
+            setVisible(window.scrollY > SHOW_AFTER_PX);
+        };
+
+        // In case the page is already scrolled on mount (e.g. back/forward nav)
+        onScroll();
+
+        window.addEventListener("scroll", onScroll, { passive: true });
+        return () => window.removeEventListener("scroll", onScroll);
+    }, []);
+
+    const scrollToTop = () => {
+        window.scrollTo({
+            top: 0,
+            behavior: "smooth",
+        });
+    };
+
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.button
+                    type="button"
+                    onClick={scrollToTop}
+                    initial={{ opacity: 0, y: 12, scale: 0.9 }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: 12, scale: 0.9 }}
+                    transition={{ duration: 0.2, ease: "easeOut" }}
+                    whileHover={{ scale: 1.05 }}
+                    whileTap={{ scale: 0.95 }}
+                    aria-label="Scroll to top"
+                    className="fixed z-50 bottom-24 right-5 w-12 h-12 bg-stone-900 text-white
+                     rounded-full shadow-lg flex items-center justify-center
+                     hover:bg-stone-700 transition-colors"
+                >
+                    <span className="text-lg leading-none">↑</span>
+                </motion.button>
+            )}
+        </AnimatePresence>
+    );
+}


### PR DESCRIPTION
## 📋 What does this PR do?
Adds a reusable, globally-mounted "scroll to top" floating action button (FAB). It stays hidden on page load, fades in once the user scrolls past ~500px, and smoothly scrolls back to the top of the page on click.


## 🔗 Related Issue
Closes #780

## 🧪 How was this tested?
- Manually tested on `/`, `/home`, `/product/:id`, `/checkout`, `/profile`, `/plans/weight-loss`, `/admin/dashboard`, `/auth`, and a bad route (404) to confirm the FAB appears consistently across all page types, including ones not wrapped by `NonAdminRoute`/`AdminRoute`.
- Confirmed the button is hidden at scroll position 0 and fades in only after crossing the 500px threshold.
- Confirmed clicking it smooth-scrolls to the top and fades out again once back near the top.
- Verified the scroll event listener is removed on unmount (checked via React DevTools / no console warnings on hot reload).
- Checked it doesn't visually collide with the existing `FitnessChatBot` FAB on `/home` (offset above it at `bottom-24`).


## 📸 Screenshots (if UI changes)
Before: no floating control visible after scrolling down a page.
After: a small circular stone-900 button with an up arrow appears bottom-right once scrolled past 500px; clicking it smooth-scrolls to top.


## ✅ Checklist
- [ x ] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys