### PR TITLE
fix: add placeholder handlers for homepage buttons

### DIFF
--- a/client/src/pages/HomePage.jsx
+++ b/client/src/pages/HomePage.jsx
@@ -20,6 +20,9 @@ import ProductCardSkeleton from "../components/ProductCardSkeleton";
 import useInfiniteProducts from "../hooks/useInfiniteProducts";
 import CategoryPillsSkeleton from "../components/CategoryPillsSkeleton";
 
+const handleComingSoon = (feature) => {
+  window.alert(`${feature} is coming soon!`);
+};
 
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
@@ -611,7 +614,7 @@ export default function HomePage() {
                 Points for every purchase and every fitness milestone. Redeem against equipment, supplements, or coaching.
               </p>
             </div>
-            <button className="shrink-0 bg-stone-900 text-white text-sm px-6 sm:px-7 py-3 rounded-full
+            <button onClick={() => handleComingSoon("Loyalty Program")} className="shrink-0 bg-stone-900 text-white text-sm px-6 sm:px-7 py-3 rounded-full
                                hover:bg-stone-700 transition-colors self-start md:self-auto w-full sm:w-auto
                                text-center">
               Learn More
@@ -652,7 +655,7 @@ export default function HomePage() {
                   </div>
                   <p className="text-sm text-stone-500 leading-relaxed">{p.desc}</p>
                 </div>
-                <button className="shrink-0 text-xs border border-stone-300 text-stone-700 px-5 py-2.5
+                <button onClick={() => handleComingSoon(p.cta)} className="shrink-0 text-xs border border-stone-300 text-stone-700 px-5 py-2.5
                                    rounded-full hover:bg-stone-900 hover:text-white hover:border-stone-900
                                    transition-all self-start min-h-10">
                   {p.cta}
@@ -671,7 +674,7 @@ export default function HomePage() {
           <p className="text-xs text-stone-400 text-center">© 2026 FitMart. Built at VESIT, Mumbai.</p>
           <div className="flex gap-4 sm:gap-5">
             {["Privacy", "Terms", "Support"].map(l => (
-              <button key={l}
+              <button key={l} onClick={() => handleComingSoon(l)}
                 className="text-xs text-stone-400 hover:text-stone-600 transition-colors min-h-9 px-1">
                 {l}
               </button>


### PR DESCRIPTION
Fixes #348

### Changes
- Added placeholder click handler for Learn More
- Added placeholder click handlers for Upgrade buttons
- Added placeholder click handlers for Privacy, Terms, and Support buttons