### PR TITLE
feat: migrate from static VITE_ADMIN_UID to Role-Based Access Control

### DIFF
--- a/client/src/auth/useAuth.js
+++ b/client/src/auth/useAuth.js
@@ -1,15 +1,69 @@
 import { useState, useEffect } from 'react';
 import { onAuthStateChanged } from 'firebase/auth';
 import { auth } from './firebase';
+import { getAuthHeaders } from '../utils/getAuthHeaders';
+
+const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
 export function useAuth() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
+
   useEffect(() => {
-    return onAuthStateChanged(auth, (u) => {
-      setUser(u);
-      setLoading(false);
+    let mounted = true;
+
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (!mounted) return;
+
+      if (!firebaseUser) {
+        setUser(null);
+        setLoading(false);
+        return;
+      }
+
+      // Try to fetch the user's role from the backend
+      try {
+        const headers = await getAuthHeaders();
+        const res = await fetch(`${API}/api/user/profile/${firebaseUser.uid}`, {
+          headers,
+          credentials: "include",
+        });
+
+        if (res.ok) {
+          const profile = await res.json();
+          if (mounted) {
+            setUser({
+              ...firebaseUser,
+              role: profile.role || 'user',
+            });
+          }
+        } else {
+          // Profile doesn't exist yet — default to 'user'
+          if (mounted) {
+            setUser({
+              ...firebaseUser,
+              role: 'user',
+            });
+          }
+        }
+      } catch (err) {
+        // Offline or server error — use Firebase user with default role
+        if (mounted) {
+          setUser({
+            ...firebaseUser,
+            role: 'user',
+          });
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
     });
+
+    return () => {
+      mounted = false;
+      unsubscribe();
+    };
   }, []);
+
   return { user, loading };
 }

--- a/client/src/components/AdminRoute.jsx
+++ b/client/src/components/AdminRoute.jsx
@@ -1,22 +1,20 @@
-import React from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
-
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
-const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
-const DEV_ADMIN_EMAIL = import.meta.env.VITE_DEV_ADMIN_EMAIL || '';
 
 export default function AdminRoute({ children }) {
   const { user, loading } = useAuth();
 
   if (loading) return null;
   if (!user) return <Navigate to="/auth" replace />;
-  // In development allow a local dev admin session
+
+  // Dev admin fallback: allow access if dev_token is present
   if (import.meta.env.MODE === 'development') {
-    const isDevLocal = localStorage.getItem('dev_token') && (DEV_ADMIN_EMAIL ? true : true);
-    if (isDevLocal) return children;
+    const hasDevToken = localStorage.getItem('dev_token');
+    if (hasDevToken) return children;
   }
 
-  if (user.uid !== ADMIN_UID && user.uid !== SUPER_ADMIN_UID) return <Navigate to="/home" replace />;
+  // Check role from the database (set via UserProfile)
+  if (user.role !== 'admin') return <Navigate to="/home" replace />;
+
   return children;
 }

--- a/client/src/components/NonAdminRoute.jsx
+++ b/client/src/components/NonAdminRoute.jsx
@@ -1,10 +1,7 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "../auth/useAuth";
 import ReportBugButton from "./ReportBugButton";
-
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID || "n5LtrXIGVSVjNktRn1PgDXZbHgq1";
-const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
 
 export default function NonAdminRoute({ children }) {
   const { user, loading } = useAuth();
@@ -19,7 +16,8 @@ export default function NonAdminRoute({ children }) {
 
   if (loading) return null;
 
-  if (user && (user.uid === ADMIN_UID || user.uid === SUPER_ADMIN_UID)) {
+  // Redirect admins away from non-admin pages
+  if (user && user.role === 'admin') {
     return <Navigate to="/admin/dashboard" replace />;
   }
 

--- a/client/src/pages/Authentication.jsx
+++ b/client/src/pages/Authentication.jsx
@@ -16,8 +16,26 @@ import {
 import { auth } from "../auth/firebase";
 import { useGithubStats } from "../utils/useGithubStats";
 
-const ADMIN_UID = import.meta.env.VITE_ADMIN_UID;
 const SUPER_ADMIN_UID = import.meta.env.VITE_SUPER_ADMIN_UID || '';
+const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
+
+// Fetch the user's role from the backend to determine navigation destination
+async function getRedirectPath(user) {
+  try {
+    const token = await user.getIdToken();
+    const res = await fetch(`${API}/api/user/profile/${user.uid}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
+    });
+    if (res.ok) {
+      const profile = await res.json();
+      if (profile.role === 'admin') return '/admin/dashboard';
+    }
+  } catch (err) {
+    console.error('Failed to fetch user role:', err);
+  }
+  return '/home';
+}
 
 const formatStat = (n, loading) => (loading ? "—" : Number(n).toLocaleString("en-IN"));
 
@@ -78,7 +96,8 @@ export default function Authentication() {
           await auth.currentUser.reload();
           if (auth.currentUser.emailVerified || auth.currentUser.uid === SUPER_ADMIN_UID) {
             clearInterval(pollInterval);
-            navigate(auth.currentUser.uid === ADMIN_UID || auth.currentUser.uid === SUPER_ADMIN_UID ? "/admin/dashboard" : "/home");
+            const path = await getRedirectPath(auth.currentUser);
+            navigate(path);
           }
         } catch (err) {
           console.error("Failed to reload user:", err);
@@ -118,7 +137,8 @@ export default function Authentication() {
         setMode("pending-verification");
         return;
       }
-      navigate(cred?.user?.uid === ADMIN_UID || cred?.user?.uid === SUPER_ADMIN_UID ? "/admin/dashboard" : "/home");
+      const path = await getRedirectPath(cred.user);
+      navigate(path);
     } catch (err) {
       console.error('handleSignIn error', err);
       setError(parseError(err.code));
@@ -169,7 +189,8 @@ export default function Authentication() {
         }
       }
       if (cred && cred.user) {
-        navigate(cred.user.uid === ADMIN_UID || cred.user.uid === SUPER_ADMIN_UID ? "/admin/dashboard" : "/home");
+        const path = await getRedirectPath(cred.user);
+        navigate(path);
       }
     } catch (err) {
       console.error('handleGoogle error', err);
@@ -187,7 +208,8 @@ export default function Authentication() {
         const result = await getRedirectResult(auth);
         if (!mounted || !result || !result.user) return;
         const u = result.user;
-        navigate(u.uid === ADMIN_UID || u.uid === SUPER_ADMIN_UID ? "/admin/dashboard" : "/home");
+        const path = await getRedirectPath(u);
+        navigate(path);
       } catch (err) {
         // Not an error in many cases (no redirect result), but log for debugging
         if (err && err.code) console.error('getRedirectResult error', err);

--- a/server/middleware/verifyAdmin.js
+++ b/server/middleware/verifyAdmin.js
@@ -1,21 +1,28 @@
 // server/middleware/verifyAdmin.js
-const ADMIN_UID = process.env.ADMIN_UID || process.env.VITE_ADMIN_UID || '';
-const SUPER_ADMIN_UID = process.env.SUPER_ADMIN_UID || process.env.VITE_SUPER_ADMIN_UID || '';
-const DEV_ADMIN_EMAIL = process.env.DEV_ADMIN_EMAIL || '';
-const isDev = process.env.NODE_ENV !== 'production';
+const UserProfile = require('../models/UserProfile');
 
-const verifyAdmin = (req, res, next) => {
+const verifyAdmin = async (req, res, next) => {
   if (!req.user) {
     return res.status(401).json({ error: 'Unauthorized — no user found' });
   }
 
-  // Production check: match UIDs
-  const isProductionAuthorized = (ADMIN_UID && req.user.uid === ADMIN_UID) ||
-    (SUPER_ADMIN_UID && req.user.uid === SUPER_ADMIN_UID);
+  try {
+    const profile = await UserProfile.findOne({ userId: req.user.uid });
+    if (profile && profile.role === 'admin') return next();
+  } catch (err) {
+    console.error('verifyAdmin db error:', err.message);
+  }
 
-  if (isProductionAuthorized) return next();
+  // Fallback: allow matching env UIDs for backward compatibility
+  // during migration until all admins have role='admin' in the database
+  const ADMIN_UID = process.env.ADMIN_UID || process.env.VITE_ADMIN_UID || '';
+  const SUPER_ADMIN_UID = process.env.SUPER_ADMIN_UID || process.env.VITE_SUPER_ADMIN_UID || '';
+  if (ADMIN_UID && req.user.uid === ADMIN_UID) return next();
+  if (SUPER_ADMIN_UID && req.user.uid === SUPER_ADMIN_UID) return next();
 
   // Development: allow matching dev admin email or uid when running locally
+  const DEV_ADMIN_EMAIL = process.env.DEV_ADMIN_EMAIL || '';
+  const isDev = process.env.NODE_ENV !== 'production';
   if (isDev) {
     if (DEV_ADMIN_EMAIL && req.user.email && req.user.email === DEV_ADMIN_EMAIL) return next();
     if (process.env.DEV_ADMIN_UID && req.user.uid === process.env.DEV_ADMIN_UID) return next();

--- a/server/models/UserProfile.js
+++ b/server/models/UserProfile.js
@@ -4,6 +4,7 @@ const mongoose = require("mongoose");
 const userProfileSchema = new mongoose.Schema(
   {
     userId: { type: String, required: true, unique: true }, // Firebase UID
+    role: { type: String, enum: ['user', 'admin'], default: 'user' },
     isFirstLogin: { type: Boolean, default: true },              // false after first login banner is shown
     discountUsed: { type: Boolean, default: false },              // true after first order is placed
     discountPercent: { type: Number, default: 10 },              // 10% welcome discount

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -57,6 +57,7 @@ router.post("/login", async (req, res) => {
         showBanner: true,
         discountUsed: false,
         discountPercent: profile.discountPercent,
+        role: profile.role,
       });
     }
 
@@ -76,6 +77,7 @@ router.post("/login", async (req, res) => {
         showBanner: true,
         discountUsed: profile.discountUsed,
         discountPercent: profile.discountPercent,
+        role: profile.role,
       });
     }
 
@@ -84,6 +86,7 @@ router.post("/login", async (req, res) => {
       showBanner: false,
       discountUsed: profile.discountUsed,
       discountPercent: profile.discountPercent,
+      role: profile.role,
     });
   } catch (err) {
     console.error("user/login error:", err);


### PR DESCRIPTION
## Description

Closes #791

Replaces the hardcoded `VITE_ADMIN_UID` environment variable checks with a proper `role` field on the `UserProfile` model. Admins can now be managed dynamically via the database instead of requiring env var changes and server restarts.

### Backend Changes

| File | Change |
|------|--------|
| `server/models/UserProfile.js` | Added `role: { type: String, enum: ['user', 'admin'], default: 'user' }` |
| `server/routes/user.js` | `POST /api/user/login` now returns `role` in all 3 response branches (new user, first login, returning user) |
| `server/middleware/verifyAdmin.js` | Checks `UserProfile.role === 'admin'` from DB first, with backward-compatible env UID fallback during migration |

### Frontend Changes

| File | Change |
|------|--------|
| `client/src/auth/useAuth.js` | Fetches `user.role` from `GET /api/user/profile/:userId` on auth state change; defaults to `'user'` on error |
| `client/src/components/AdminRoute.jsx` | Checks `user.role === 'admin'` instead of `VITE_ADMIN_UID`; keeps dev_token fallback |
| `client/src/components/NonAdminRoute.jsx` | Checks `user.role === 'admin'` for redirect; removed `VITE_ADMIN_UID`/`VITE_SUPER_ADMIN_UID` imports |
| `client/src/pages/Authentication.jsx` | Added `getRedirectPath` helper that fetches role from profile endpoint; all 4 navigation points now use role-based redirect instead of UID comparison |

### Migration Note

Existing admin UIDs (set via `VITE_ADMIN_UID` env var) still work via the backward-compatible fallback in `verifyAdmin.js`. To fully migrate, set `role: 'admin'` on the admin's UserProfile document in the database. Once done, the env vars can be safely removed.