### PR TITLE
feat(server): add SIGTERM and SIGINT graceful shutdown (Fixes #719)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@
 require("dotenv").config();
 const rewardsRoutes = require("./routes/rewards");
 const express = require("express");
+const mongoose = require("mongoose");
 const cors = require("cors");
 const helmet = require("helmet");
 const rateLimit = require("express-rate-limit");
@@ -199,7 +200,25 @@ app.use((err, req, res, next) => {
   res.status(500).json({ error: "Something went wrong" });
 });
 
-app.listen(port, () => {
+const server = app.listen(port, () => {
   console.log(`Server listening on port ${port}`);
   console.log(`CORS allowed origins: ${allowedOrigins.join(", ")}`);
 });
+
+// ── Graceful Shutdown ────────────────────────────────────────────────────────
+const gracefulShutdown = (signal) => {
+  console.log(`${signal} received: closing HTTP server`);
+  server.close(async () => {
+    console.log("HTTP server closed.");
+    try {
+      await mongoose.connection.close();
+      console.log("MongoDB connection closed.");
+    } catch (err) {
+      console.error("Error closing MongoDB connection:", err);
+    }
+    process.exit(0);
+  });
+};
+
+process.on("SIGTERM", () => gracefulShutdown("SIGTERM"));
+process.on("SIGINT", () => gracefulShutdown("SIGINT"));


### PR DESCRIPTION
## 📋 What does this PR do?
Adds SIGTERM and SIGINT graceful shutdown handlers to close the HTTP server and Mongoose connection cleanly.

## 🔗 Related Issue
Closes #719

## 🧪 How was this tested?
Tested server shutdown signals locally.

## 📸 Screenshots (if UI changes)
Before / After screenshots if you changed any UI.

## ✅ Checklist
- [ ] I've read the CONTRIBUTING guide
- [ ] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [ ] I've linked the related issue
- [ ] I haven't introduced any new secrets or API keys