### PR TITLE
feat: add pagination to GET /api/customers endpoint

### DIFF
--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -44,7 +44,12 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
   try {
     console.log('[API] GET /customers request received');
 
-    const customers = await Order.aggregate([
+    // ── Pagination params ─────────────────────────────────────────────────
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 50));
+    const skip = (page - 1) * limit;
+
+    const aggResult = await Order.aggregate([
       { $match: { status: 'paid' } },
       {
         $group: {
@@ -66,13 +71,27 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
           lastOrder: 1,
         },
       },
+      {
+        $facet: {
+          metadata: [{ $count: 'total' }],
+          data: [{ $skip: skip }, { $limit: limit }],
+        },
+      },
     ]);
 
-    console.log(`[API] Found ${customers.length || 0} customers from orders`);
+    const total = aggResult[0]?.metadata[0]?.total || 0;
+    const customers = aggResult[0]?.data || [];
+    const totalPages = Math.ceil(total / limit);
+
+    console.log(`[API] Found ${total} total customers, returning page ${page}/${totalPages} (${customers.length} records)`);
 
     if (!customers || customers.length === 0) {
       console.log('[API] No customers found, returning empty list');
-      return res.json({ success: true, data: [] });
+      return res.json({
+        success: true,
+        data: [],
+        pagination: { page, limit, total, totalPages },
+      });
     }
 
     // Deduplicate UIDs and resolve Firebase user info + UserProfile in parallel
@@ -112,7 +131,11 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     });
 
     console.log(`[API] Returning ${result.length} enriched customers`);
-    res.json({ success: true, data: result });
+    res.json({
+      success: true,
+      data: result,
+      pagination: { page, limit, total, totalPages },
+    });
   } catch (err) {
     console.error('[API] GET /customers error:', err);
     res.status(500).json({ success: false, error: err.message || 'Server error' });


### PR DESCRIPTION
## Description

Adds pagination support to the `GET /api/customers` admin endpoint. Previously, the endpoint returned **all** customers in a single response — no pagination, no limit. As the customer base grows, this becomes slow, memory-heavy, and risks timeouts on serverless platforms.

This change uses MongoDB's `$facet` to compute both the **paginated page** and the **total count** in a **single aggregation query** — no performance penalty from separate count queries.

## Changes Made

### `server/routes/customers.js`

- **Parse pagination params:** `?page=1&limit=50` (defaults: page=1, limit=50; limit capped at 100).
- **Use `$facet` in aggregation:** splits the aggregation into two sub-pipelines after sorting — `metadata` (total count) and `data` (skip + limit).
- **Return pagination metadata** in the response: `{ page, limit, total, totalPages }`.
- **Empty state:** returns `{ data: [], pagination: { ... } }` instead of bare `{ data: [] }`. The existing `GET /api/customers/:userId` and `POST /api/customers/:userId/send-reminder` routes are unchanged.

## Backward Compatibility

✅ The `data` field in the response is preserved — existing frontend code continues to work.
✅ No params → defaults to `page=1, limit=50`, so it returns the top 50 customers instead of all.
⚠️ The frontend (`AdminCustomers.jsx`) does not yet consume the `pagination` object — that's a separate UI task.

## Testing

- Manual verification with curl using `?page=1&limit=5` confirms correct pagination.
- Existing behavior for the single-customer detail and reminder routes is untouched.

## Closes

Closes #834
