### PR TITLE
refactor: use shared LOW_STOCK_THRESHOLD constant

### DIFF
--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -1,4 +1,6 @@
 // server/routes/dashboard.js
+
+const { LOW_STOCK_THRESHOLD } = require('../config/constants');
 const express = require('express');
 const router = express.Router();
 const Order = require('../models/Order');
@@ -50,7 +52,7 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
+    
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });


### PR DESCRIPTION
## 📋 What does this PR do?
This PR removes the hardcoded `LOW_STOCK_THRESHOLD` value from `server/routes/dashboard.js` and uses the shared constant from `server/config/constants.js`. This centralizes the configuration and avoids hardcoded values.

## 🔗 Related Issue
Closes #836 

## 🧪 How was this tested?
- Verified that `LOW_STOCK_THRESHOLD` is imported from `server/config/constants.js`.
- Confirmed the hardcoded value was removed from `dashboard.js`.
- I was unable to fully run the backend locally because `npm install` failed due to a dependency installation issue (`mongodb-memory-server`).

## 📸 Screenshots (if UI changes)
N/A (No UI changes)

## ✅ Checklist
- [✅] I've read the CONTRIBUTING guide
- [✅] My code follows the project's style guidelines
- [ ] I've tested my changes locally
- [✅] I've linked the related issue
- [✅] I haven't introduced any new secrets or API keys