### PR TITLE
fix: use shared LOW_STOCK_THRESHOLD constant in dashboard.js (fixes #…

### DIFF
--- a/server/routes/dashboard.js
+++ b/server/routes/dashboard.js
@@ -7,6 +7,7 @@ const admin = require('../firebaseAdmin');
 const verifyFirebaseToken = require('../middleware/verifyFirebaseToken');
 const verifyAdmin = require('../middleware/verifyAdmin');
 const resolveFirebaseUser = require('../lib/resolveFirebaseUser');
+const { LOW_STOCK_THRESHOLD } = require('../config/constants');
 
 // ── Helper: get the start date based on the time range filter
 // 'today'  -> start of today
@@ -50,7 +51,6 @@ router.get('/', verifyFirebaseToken, verifyAdmin, async (req, res) => {
     const totalCustomers = uniqueCustomers.length;
 
     // ── 3. KPI: Products Low on Stock ─────────────────────────────────────
-    const LOW_STOCK_THRESHOLD = 10;
     const lowStockCount = await Product.countDocuments({
       stock: { $ne: null, $lt: LOW_STOCK_THRESHOLD },
     });


### PR DESCRIPTION
## 📋 What does this PR do?
Fixes an inconsistency where the low-stock threshold was hardcoded separately 
in `dashboard.js` (value: 10) instead of using the shared `LOW_STOCK_THRESHOLD` 
constant from `config/constants.js` (value: 5), which `products.js` already 
correctly used. This caused the dashboard KPI and the `/api/products/low-stock` 
endpoint to disagree on which products count as "low stock."

The fix removes the local hardcoded value in `dashboard.js` and imports the 
shared constant instead, matching the pattern already used in `products.js`.

## 🔗 Related Issue
Closes #242

## 🧪 How was this tested?
Verified the modified file has no syntax errors using `node --check routes/dashboard.js`. 
Full end-to-end testing requires a live MongoDB/Firebase connection not available 
in my local setup, but the change is a minimal, isolated one-line fix that mirrors 
an existing working pattern in `products.js`.

## 📸 Screenshots (if UI changes)
N/A — backend-only change, no UI impact.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys