### PR TITLE
Remove leftover debug logging from ExercisePage

### DIFF
--- a/client/src/pages/ExercisePage.jsx
+++ b/client/src/pages/ExercisePage.jsx
@@ -60,19 +60,6 @@ export default function ExercisePage() {
 
       const data = await response.json();
 
-      // Client-side debug logging
-      if (data && data.length > 0) {
-        const firstEx = data[0];
-        console.log(`\n[Exercise Client] Received ${data.length} exercises for "${bodyPart}"`);
-        console.log("  First exercise name:", firstEx.name);
-        console.log("  First exercise gifUrl:", firstEx.gifUrl ? `✅ Present` : "❌ null");
-        console.log("  First exercise imageUrl:", firstEx.imageUrl ? `✅ Present` : "❌ null");
-        if (firstEx.gifUrl) {
-          console.log("  GIF URL preview:", firstEx.gifUrl.substring(0, 100));
-        }
-        console.log("");
-      }
-
       setExercises(data || []);
     } catch (err) {
       setError(err.message || "Failed to load exercises. Please try again.");


### PR DESCRIPTION
## What
Removes a block of debug `console.log` statements in `ExercisePage.jsx` that was logging exercise data (names, GIF/image URL previews) to the browser console on every fetch.

## Why
This looks like leftover debugging code that shouldn't ship to production — it exposes internal data details in the browser console for every user and adds unnecessary noise.

## Changes
- Removed the `// Client-side debug logging` block and its console.log calls
- No functional changes — `setExercises(data || [])` still runs exactly as before