### PR TITLE
fix(server): remove deprecated useNewUrlParser and useUnifiedTopology from seed.js

### DIFF
--- a/server/seed.js
+++ b/server/seed.js
@@ -309,7 +309,9 @@ const PRODUCTS = [
 async function seed() {
   try {
     console.log('Connecting to MongoDB...');
-    await mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true, ...(process.env.MONGO_DB ? { dbName: process.env.MONGO_DB } : {}) });
+    await mongoose.connect(MONGO_URI, {
+    ...(process.env.MONGO_DB ? { dbName: process.env.MONGO_DB } : {})
+});
     console.log('Connected —', 'database:', mongoose.connection.name, 'host:', mongoose.connection.host, ' — seeding products');
 
     await Product.deleteMany({});


### PR DESCRIPTION
## 📋 What does this PR do?
Removes deprecated Mongoose driver options (`useNewUrlParser` and `useUnifiedTopology`) from `server/scripts/seed.js`. These options were completely removed in Mongoose v7+ and cause a `MongoParseError` crash when running `npm run seed` on modern Mongoose versions (v9+).

### Summary of Changes:
* Cleaned up `mongoose.connect()` in `server/scripts/seed.js` to use standard Mongoose v9 syntax.

---

## 🔗 Related Issue
Closes #862

---

## 🧪 How was this tested?
1. Ran `cd server && npm run seed` locally.
2. Confirmed the MongoDB connection establishes successfully without throwing `MongoParseError`.
3. Verified that sample products are seeded cleanly into the database.

---

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue (#862)