### PR TITLE
feat: expand Zod validation to /api/user and /api/customers

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6294,6 +6294,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
@@ -6361,6 +6378,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -6,6 +6,8 @@ const cloudinary = require("../lib/cloudinary");
 const UserProfile = require("../models/UserProfile");
 const admin = require("../firebaseAdmin");
 const verifyFirebaseToken = require("../middleware/verifyFirebaseToken");
+const validateRequest = require("../middleware/validateRequest");
+const { userProfileUpdateSchema } = require("../validation/requestSchemas");
 const router = express.Router();
 
 // Use memory storage for serverless environments
@@ -195,25 +197,13 @@ router.get("/profile/:userId", async (req, res) => {
 // Body: fields to merge into profile (name, phone, addresses, defaultAddressId)
 // Creates profile if missing.
 // ─────────────────────────────────────────────────────────────────────────────
-router.put("/profile/:userId", async (req, res) => {
+router.put("/profile/:userId", validateRequest(userProfileUpdateSchema), async (req, res) => {
   try {
     const { userId } = req.params;
-    if (!userId) return res.status(400).json({ error: "userId required" });
-
-    const phoneRegex = /^\+?[\d\s\-]{7,15}$/;
-    if (req.body.phone && !phoneRegex.test(req.body.phone)) {
-      return res.status(400).json({ error: "Invalid phone number format" });
-    }
-
-    const update = {};
-    const allowed = ["name", "phone", "addresses", "defaultAddressId", "photoURL"];
-    for (const k of allowed) {
-      if (req.body[k] !== undefined) update[k] = req.body[k];
-    }
 
     const profile = await UserProfile.findOneAndUpdate(
       { userId },
-      { $set: update },
+      { $set: req.body },
       { upsert: true, returnDocument: 'after' }
     );
 

--- a/server/validation/requestSchemas.js
+++ b/server/validation/requestSchemas.js
@@ -74,6 +74,34 @@ const workoutLogBodySchema = z.object({
   exercises: z.array(workoutExerciseSchema).optional()
 }).strict();
 
+const addressSchema = z.object({
+  id: z.string().optional(),
+  _id: z.string().optional(),
+  label: z.string().optional(),
+  line1: z.string().optional(),
+  line2: z.string().optional(),
+  city: z.string().optional(),
+  state: z.string().optional(),
+  zip: z.string().optional(),
+  country: z.string().optional(),
+  phone: z.string().optional(),
+}).strict();
+
+const userProfileUpdateBodySchema = z.object({
+  name: z.string().trim().min(1, 'name cannot be empty').optional(),
+  phone: z.string().regex(/^\+?[\d\s\-]{7,15}$/, 'Invalid phone number format').optional(),
+  addresses: z.array(addressSchema).optional(),
+  defaultAddressId: z.string().optional(),
+  photoURL: z.string().optional(),
+}).strict();
+
+const customerUpdateBodySchema = z.object({
+  name: z.string().trim().min(1, 'name cannot be empty').optional(),
+  phone: z.string().regex(/^\+?[\d\s\-]{7,15}$/, 'Invalid phone number format').optional(),
+  email: z.string().email('Invalid email address').optional(),
+  notes: z.string().optional(),
+}).strict();
+
 module.exports = {
   cartAddSchema: {
     params: userIdParamsSchema,
@@ -98,5 +126,13 @@ module.exports = {
   },
   updateWorkoutLogSchema: {
     body: workoutLogBodySchema,
+  },
+  userProfileUpdateSchema: {
+    params: z.object({ userId: z.string().min(1, 'userId is required') }),
+    body: userProfileUpdateBodySchema,
+  },
+  customerUpdateSchema: {
+    params: z.object({ userId: z.string().min(1, 'userId is required') }),
+    body: customerUpdateBodySchema,
   },
 };


### PR DESCRIPTION
Closes #865

**Changes:**

1. **`server/validation/requestSchemas.js`** — Added three new Zod schemas:
   - `addressSchema` — validates address subdocuments (id, _id, label, line1, line2, city, state, zip, country, phone; all optional, strict)
   - `userProfileUpdateBodySchema` — validates profile update body (name, phone with regex, addresses array, defaultAddressId, photoURL; all optional, strict)
   - `customerUpdateBodySchema` — validates customer update body (name, phone, email, notes; all optional, strict)
   - Exported `userProfileUpdateSchema` and `customerUpdateSchema` following the existing `{ params, body }` pattern

2. **`server/routes/user.js`** — Updated `PUT /api/user/profile/:userId`:
   - Added `validateRequest` and `userProfileUpdateSchema` imports
   - Applied `validateRequest(userProfileUpdateSchema)` middleware before the handler
   - Removed manual `if (!userId)` check (handled by Zod params validation)
   - Removed manual phone regex validation (moved to Zod schema)
   - Removed allowed-fields whitelist loop (replaced by `.strict()` on the schema)
   - Using validated `req.body` directly in `$set` instead of the manual `update` object

3. **`server/routes/customers.js`** — ⚠️ _No PUT route exists in this file._ The `customerUpdateSchema` is exported from `requestSchemas.js` for future use when a `PUT /api/customers/:userId` route is added.

**Note:** The `PUT /api/customers/:id` route mentioned in the issue does not currently exist in the codebase, so the `customerUpdateSchema` is exported but not yet consumed by any route handler.