### PR TITLE
fix: unify low-stock threshold (env + client constant)

### DIFF
--- a/client/src/constants/inventory.js
+++ b/client/src/constants/inventory.js
@@ -1,0 +1,3 @@
+// Keep in sync with server LOW_STOCK_THRESHOLD (default 5).
+// Server can override via env; the client badge uses this constant.
+export const LOW_STOCK_THRESHOLD = 5;

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -3,8 +3,8 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import { LOW_STOCK_THRESHOLD } from "../constants/inventory";
 
-const LOW_STOCK_THRESHOLD = 5;
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
 
 const statusConfig = (p) => {

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,10 @@
 NODE_ENV=development
 PORT=5000
 
+# Products below this available stock count as "low stock"
+# (dashboard KPI + products route). Default 5 if unset.
+LOW_STOCK_THRESHOLD=5
+
 ALLOWED_ORIGIN=http://localhost:5173
 APP_BASE_URL=http://localhost:5173
 

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -1,16 +1,23 @@
 // server/config/constants.js
 
+function intEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw == null || String(raw).trim() === "") return fallback;
+  const n = parseInt(String(raw), 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 const CONSTANTS = {
-  // Stock Thresholds
-  LOW_STOCK_THRESHOLD: 5,
+  // Stock Thresholds — override with LOW_STOCK_THRESHOLD in server/.env
+  LOW_STOCK_THRESHOLD: intEnv("LOW_STOCK_THRESHOLD", 5),
 
   // Server Config
   DEFAULT_PORT: 5000,
 
   // Rate Limiting
   RATE_LIMIT_WINDOW_MS: 15 * 60 * 1000, // 15 minutes
-  API_LIMIT_MAX: 100,                   // Limit each IP to 100 requests per window
-  PAYMENT_LIMIT_MAX: 20,                // Stricter limit for payments
+  API_LIMIT_MAX: 100, // Limit each IP to 100 requests per window
+  PAYMENT_LIMIT_MAX: 20, // Stricter limit for payments
 };
 
 module.exports = CONSTANTS;


### PR DESCRIPTION
## What
Low stock used different numbers depending on which screen you looked at (dashboard vs inventory). Silent mismatch for stock in the middle.

## Changes
- `server/config/constants.js` — read `LOW_STOCK_THRESHOLD` from env, default `5`
- products + dashboard already import that constant
- `client/src/constants/inventory.js` so the admin inventory page doesn't hardcode it
- documented the env var in `server/.env.example`

Fixes #242

## Notes
Left the client default at 5 to match the server default. If you ever need the client to follow a different deploy-time value, we could expose it from an API later.