### PR TITLE
chore: sync server/package-lock.json with package.json

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6294,6 +6294,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
@@ -6361,6 +6378,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {


### PR DESCRIPTION
### Description

Regenerates `server/package-lock.json` by running `npm install` to fix the out-of-sync lock file that was causing `npm ci` to fail in CI.

### Problem

The CI workflow for backend tests fails with:
```
npm error Missing: gcp-metadata@7.0.1 from lock file
```

This blocks every open PR that runs the backend test suite, even when the PR does not touch any server code.

### Fix

Ran `npm install` in the `server/` directory. The only change is the regenerated `server/package-lock.json` (33 insertions). No code changes.

Fixes #877