### PR TITLE
fix(navbar): show compact github star button on mobile and tablet

### DIFF
--- a/client/src/pages/LandingPage.jsx
+++ b/client/src/pages/LandingPage.jsx
@@ -647,12 +647,12 @@ function NavbarWithGithub({ navOpaque, menuOpen, setMenuOpen, ghStats, ghLoading
 
         {/* Right */}
         <div className="flex items-center gap-2">
-          {/* GitHub Star — visible on sm+ in nav, hidden on mobile to save space */}
+          {/* GitHub Star — always visible; compact (icon + count) on mobile, full label on sm+ */}
           <a
             href={GITHUB_REPO}
             target="_blank"
             rel="noopener noreferrer"
-            className={`hidden sm:flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-full
+            className={`flex items-center gap-1.5 text-xs px-2.5 sm:px-3 py-1.5 rounded-full
                           border transition-all min-h-8.5
                           ${isOpaque
                 ? "border-stone-200 text-stone-600 hover:bg-stone-900 hover:text-white hover:border-stone-900"
@@ -661,7 +661,7 @@ function NavbarWithGithub({ navOpaque, menuOpen, setMenuOpen, ghStats, ghLoading
           >
             <GithubIcon className="w-3.5 h-3.5" />
             <StarIcon className="w-3 h-3" />
-            <span>Star</span>
+            <span className="hidden sm:inline">Star</span>
             <span className={`text-[10px] px-1.5 py-0.5 rounded-full font-medium
                                 ${isOpaque ? "bg-stone-100 text-stone-700" : "bg-white/10 text-white/70"}`}>
               {formatStat(ghStats.stars, ghLoading)}


### PR DESCRIPTION
## 📋 What does this PR do?
Makes the GitHub Star button in the navbar always visible instead of being
hidden below the `sm` breakpoint (640px). Previously it used `hidden sm:flex`,
which removed it entirely from the layout on mobile and tablet screens. Now
it stays visible at all screen sizes but collapses to icon + star count only
on mobile, showing the full "Star" text label at `sm:` and up — preserving
the original space-saving intent without hiding the CTA completely.

## 🔗 Related Issue
Closes #888

## 🧪 How was this tested?
- Ran the client locally (`npm run dev`) and checked the navbar at multiple
  viewport widths using browser dev tools: ~375px (mobile), ~768px (tablet),
  and ~1280px (desktop).
- Confirmed the Star button (icon + count) is visible at all three widths,
  and the "Star" text label appears starting at the `sm` breakpoint.
- Confirmed no overflow or wrapping between the brand name, star button, and
  "Get Started" button at 375px width.
- Verified the unrelated hero-section "Star on GitHub" CTA was untouched.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys