### PR TITLE
feat: add native pull to refresh for mobile lists

### DIFF
--- a/client/src/components/PullToRefresh.jsx
+++ b/client/src/components/PullToRefresh.jsx
@@ -1,0 +1,168 @@
+// src/components/PullToRefresh.jsx
+import { useEffect, useRef, useState } from "react";
+
+const THRESHOLD = 72; // px of pull needed to trigger a refresh
+const MAX_PULL = 120; // max visual pull distance
+const RESISTANCE = 0.45; // friction applied to the pull distance
+const INDICATOR_HEIGHT = 56; // matches the h-14 indicator slot
+const MIN_SPINNER_MS = 500; // keep the spinner visible for at least this long
+
+function RefreshIndicator({ progress, refreshing }) {
+  const label = refreshing
+    ? "Refreshing"
+    : progress >= 1
+      ? "Release to refresh"
+      : "Pull to refresh";
+
+  return (
+    <div className="flex flex-col items-center gap-1.5">
+      {refreshing ? (
+        <div className="h-7 w-7 animate-spin rounded-full border-2 border-stone-300 border-t-stone-900" />
+      ) : (
+        <svg
+          className="h-6 w-6 text-stone-900"
+          style={{ transform: `rotate(${progress * 180}deg)` }}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 5v12m0 0l-5-5m5 5l5-5" />
+        </svg>
+      )}
+      <span className="text-[10px] font-medium tracking-widest uppercase text-stone-400">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Native-feeling pull to refresh for touch devices.
+ * Attaches non-passive touch listeners (so the browser overscroll can be
+ * suppressed while pulling) and only arms the gesture when the window is
+ * scrolled to the very top. Calls onRefresh once the pull passes THRESHOLD.
+ */
+export default function PullToRefresh({ onRefresh, disabled = false, children }) {
+  const containerRef = useRef(null);
+  const [pullDistance, setPullDistance] = useState(0);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const refreshingRef = useRef(false);
+  const onRefreshRef = useRef(onRefresh);
+
+  useEffect(() => {
+    onRefreshRef.current = onRefresh;
+  }, [onRefresh]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || disabled) return;
+
+    // Gesture state lives in closures so the effect binds its listeners once.
+    let startY = null;
+    let pulling = false;
+    let distance = 0;
+    let cancelled = false;
+
+    const setDistance = (value) => {
+      distance = value;
+      setPullDistance(value);
+    };
+
+    const onTouchStart = (e) => {
+      if (refreshingRef.current) return;
+      if (window.scrollY > 0) return;
+      if (e.touches.length !== 1) return;
+      startY = e.touches[0].clientY;
+      pulling = true;
+    };
+
+    const onTouchMove = (e) => {
+      if (!pulling || startY === null) return;
+      const deltaY = e.touches[0].clientY - startY;
+      if (deltaY <= 0 || window.scrollY > 0) {
+        pulling = false;
+        setDistance(0);
+        return;
+      }
+      // Suppress the browser's native overscroll / pull-to-refresh while dragging.
+      if (e.cancelable) e.preventDefault();
+      setDistance(Math.min(deltaY * RESISTANCE, MAX_PULL));
+    };
+
+    const finish = () => {
+      if (!pulling) return;
+      pulling = false;
+      startY = null;
+
+      if (distance >= THRESHOLD && !refreshingRef.current) {
+        refreshingRef.current = true;
+        setRefreshing(true);
+        setDistance(0);
+
+        const startedAt = Date.now();
+        Promise.resolve(onRefreshRef.current && onRefreshRef.current())
+          .catch(() => {})
+          .finally(() => {
+            const elapsed = Date.now() - startedAt;
+            setTimeout(() => {
+              if (cancelled) return;
+              refreshingRef.current = false;
+              setRefreshing(false);
+              setPullDistance(0);
+            }, Math.max(0, MIN_SPINNER_MS - elapsed));
+          });
+      } else {
+        setDistance(0);
+      }
+    };
+
+    const opts = { passive: false };
+    el.addEventListener("touchstart", onTouchStart, opts);
+    el.addEventListener("touchmove", onTouchMove, opts);
+    el.addEventListener("touchend", finish);
+    el.addEventListener("touchcancel", finish);
+
+    return () => {
+      cancelled = true;
+      el.removeEventListener("touchstart", onTouchStart);
+      el.removeEventListener("touchmove", onTouchMove);
+      el.removeEventListener("touchend", finish);
+      el.removeEventListener("touchcancel", finish);
+    };
+  }, [disabled]);
+
+  const progress = refreshing ? 1 : Math.min(pullDistance / THRESHOLD, 1);
+  const contentY = refreshing ? INDICATOR_HEIGHT : pullDistance;
+  const indicatorY = refreshing ? 0 : pullDistance - INDICATOR_HEIGHT;
+  const settling = pullDistance === 0 || refreshing;
+
+  return (
+    <div ref={containerRef} className="relative overflow-hidden">
+      {/* Pull indicator */}
+      <div
+        className="pointer-events-none absolute left-0 right-0 top-0 z-10 flex h-14 items-center justify-center"
+        style={{
+          transform: `translateY(${indicatorY}px)`,
+          opacity: pullDistance > 0 || refreshing ? 1 : 0,
+          transition: settling ? "transform 0.25s ease, opacity 0.2s ease" : "none",
+        }}
+      >
+        <RefreshIndicator progress={progress} refreshing={refreshing} />
+      </div>
+
+      {/* Content */}
+      <div
+        style={{
+          transform: `translateY(${contentY}px)`,
+          transition: settling ? "transform 0.25s ease" : "none",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,5 +1,5 @@
 // src/pages/Profile.jsx
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
@@ -12,6 +12,7 @@ import {
   getTransactionIcon,
 } from "../utils/rewardsUtils";
 import Navbar from "../components/Navbar";
+import PullToRefresh from "../components/PullToRefresh";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -193,31 +194,33 @@ const [rewardsError, setRewardsError] = useState("");
     }
   }, [activeTab]);
 
+  // Fetch orders (used on tab mount and by pull-to-refresh)
+  // When silent (pull-to-refresh), keep the existing list visible and do not
+  // wipe it if the refresh fails.
+  const fetchOrders = useCallback(async ({ silent = false } = {}) => {
+    const user = auth.currentUser;
+    if (!user) return;
+
+    if (!silent) setLoadingOrders(true);
+    try {
+      const headers = await getAuthHeaders();
+      const res = await fetch(`${API}/api/orders/${user.uid}`, { headers, credentials: "include" });
+      if (!res.ok) throw new Error("Failed to load orders");
+      const data = await res.json();
+      setOrders(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err.message);
+      if (!silent) setOrders([]);
+    } finally {
+      if (!silent) setLoadingOrders(false);
+    }
+  }, []);
+
   // Fetch orders when orders tab is active
   useEffect(() => {
     if (activeTab !== "orders") return;
-    
-    const fetchOrders = async () => {
-      const user = auth.currentUser;
-      if (!user) return;
-      
-      setLoadingOrders(true);
-      try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/orders/${user.uid}`, { headers, credentials: "include" });
-        if (!res.ok) throw new Error("Failed to load orders");
-        const data = await res.json();
-        setOrders(Array.isArray(data) ? data : []);
-      } catch (err) {
-        setError(err.message);
-        setOrders([]);
-      } finally {
-        setLoadingOrders(false);
-      }
-    };
-
     fetchOrders();
-  }, [activeTab]);
+  }, [activeTab, fetchOrders]);
 
   const handleSaveProfile = async () => {
     const user = auth.currentUser;
@@ -528,68 +531,70 @@ const [rewardsError, setRewardsError] = useState("");
           <div>
             <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5">Order history</p>
 
-            {loadingOrders ? (
-              <div className="flex items-center justify-center py-10">
-                <span className="text-sm text-stone-400">Loading orders…</span>
-              </div>
-            ) : orders.length === 0 ? (
-              <div className="bg-white border border-stone-200 rounded-2xl p-10 text-center">
-                <p className="text-2xl mb-3">📦</p>
-                <p className="text-sm text-stone-500 mb-1">No orders yet.</p>
-                <p className="text-xs text-stone-400 mb-5">Start shopping to see your order history here.</p>
-                <button
-                  onClick={() => navigate("/home")}
-                  className="bg-stone-900 text-white text-sm px-6 py-2.5 rounded-full hover:bg-stone-700 transition-colors"
-                >
-                  Shop now
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {orders.map((order) => (
-                  <div key={order._id} className="bg-white border border-stone-200 rounded-2xl p-5 hover:border-stone-300 hover:shadow-sm transition-all">
-                    <div className="flex justify-between items-start gap-4 mb-3">
-                      <div className="flex-1">
-                        <p className="text-sm font-medium text-stone-900">
-                          {new Date(order.createdAt).toLocaleDateString('en-US', { 
-                            year: 'numeric', 
-                            month: 'long', 
-                            day: 'numeric' 
-                          })}
-                        </p>
-                        <p className="text-xs text-stone-400 mt-0.5">
-                          {order.items.length} item{order.items.length !== 1 ? 's' : ''}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="text-right">
-                          <p className="text-sm font-medium text-stone-900">₹{order.total.toFixed(2)}</p>
-                          <span className={`text-[10px] tracking-widest uppercase px-2.5 py-1 rounded-full ${
-                            order.status === 'paid' 
-                              ? 'bg-green-50 text-green-700' 
-                              : order.status === 'failed'
-                              ? 'bg-red-50 text-red-700'
-                              : 'bg-stone-100 text-stone-600'
-                          }`}>
-                            {order.status}
-                          </span>
+            <PullToRefresh onRefresh={() => fetchOrders({ silent: true })}>
+              {loadingOrders ? (
+                <div className="flex items-center justify-center py-10">
+                  <span className="text-sm text-stone-400">Loading orders…</span>
+                </div>
+              ) : orders.length === 0 ? (
+                <div className="bg-white border border-stone-200 rounded-2xl p-10 text-center">
+                  <p className="text-2xl mb-3">📦</p>
+                  <p className="text-sm text-stone-500 mb-1">No orders yet.</p>
+                  <p className="text-xs text-stone-400 mb-5">Start shopping to see your order history here.</p>
+                  <button
+                    onClick={() => navigate("/home")}
+                    className="bg-stone-900 text-white text-sm px-6 py-2.5 rounded-full hover:bg-stone-700 transition-colors"
+                  >
+                    Shop now
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {orders.map((order) => (
+                    <div key={order._id} className="bg-white border border-stone-200 rounded-2xl p-5 hover:border-stone-300 hover:shadow-sm transition-all">
+                      <div className="flex justify-between items-start gap-4 mb-3">
+                        <div className="flex-1">
+                          <p className="text-sm font-medium text-stone-900">
+                            {new Date(order.createdAt).toLocaleDateString('en-US', { 
+                              year: 'numeric', 
+                              month: 'long', 
+                              day: 'numeric' 
+                            })}
+                          </p>
+                          <p className="text-xs text-stone-400 mt-0.5">
+                            {order.items.length} item{order.items.length !== 1 ? 's' : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <div className="text-right">
+                            <p className="text-sm font-medium text-stone-900">₹{order.total.toFixed(2)}</p>
+                            <span className={`text-[10px] tracking-widest uppercase px-2.5 py-1 rounded-full ${
+                              order.status === 'paid' 
+                                ? 'bg-green-50 text-green-700' 
+                                : order.status === 'failed'
+                                ? 'bg-red-50 text-red-700'
+                                : 'bg-stone-100 text-stone-600'
+                            }`}>
+                              {order.status}
+                            </span>
+                          </div>
                         </div>
                       </div>
-                    </div>
 
-                    {/* Order items list */}
-                    <div className="pt-3 border-t border-stone-100 space-y-1.5">
-                      {order.items.map((item, idx) => (
-                        <div key={idx} className="flex justify-between text-xs text-stone-600">
-                          <span>Product ID {item.productId} × {item.quantity}</span>
-                          <span className="text-stone-900">₹{(item.price * item.quantity).toFixed(2)}</span>
-                        </div>
-                      ))}
+                      {/* Order items list */}
+                      <div className="pt-3 border-t border-stone-100 space-y-1.5">
+                        {order.items.map((item, idx) => (
+                          <div key={idx} className="flex justify-between text-xs text-stone-600">
+                            <span>Product ID {item.productId} × {item.quantity}</span>
+                            <span className="text-stone-900">₹{(item.price * item.quantity).toFixed(2)}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
+                  ))}
+                </div>
+              )}
+            </PullToRefresh>
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes #895

## Summary

Adds a native-feeling pull to refresh gesture for mobile users. Instead of relying on the barely maintained `react-simple-pull-to-refresh` package (which has known React 18/19 strict-mode quirks), this PR builds a lightweight, reusable component driven by native touch events, matching the project's existing preference for custom hooks like `useDebounce`.

## Changes

**client/src/components/PullToRefresh.jsx (NEW)**

A reusable pull-to-refresh wrapper:
- Attaches non-passive touch listeners to the wrapper element so `preventDefault()` can suppress the browser's native overscroll while pulling
- Only arms the gesture when the window is scrolled to the very top (`window.scrollY <= 0`)
- Applies a 0.45 resistance factor (max 120px pull) so the content follows the finger naturally
- Shows a down arrow that rotates as you pull, flips to "Release to refresh", then spins as a loader for a minimum 500ms
- Triggers `onRefresh` once the pull passes the 72px threshold; guards against re-entry while refreshing
- Gesture state lives in the effect closure so listeners bind once, is React 19 strict-mode safe, and cleans up listeners + pending timers on unmount

**client/src/pages/Profile.jsx (UPDATED)**

- Extracted the orders fetch into a `useCallback` so it can be reused by both the tab effect and pull-to-refresh
- Added a `silent` mode to `fetchOrders`: pull-to-refresh keeps the existing list visible (no "Loading orders..." swap) and does not wipe orders on failure, only shows the error banner
- Wrapped the orders tab content in `<PullToRefresh onRefresh={() => fetchOrders({ silent: true })}>`

## Notes

- No new dependencies added
- The component is reusable for other lists (products, bugs) via `window.scrollY`-based arming, which suits whole-page scrolling layouts

## Validation

- `vite build` passes (1130 modules transformed)
- ESLint: the local install of `eslint-plugin-react-hooks` 5.2.0 does not expose `configs.flat.recommended`, which breaks `eslint.config.js` loading for ALL files (pre-existing, unrelated to this PR); CI installs fresh and is unaffected