### PR TITLE
feat(mobile): implement native pull-to-refresh for mobile lists (#895)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1196,9 +1196,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1214,9 +1211,6 @@
             "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1234,9 +1228,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1252,9 +1243,6 @@
             "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1272,9 +1260,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1290,9 +1275,6 @@
             "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,

--- a/client/src/components/PullToRefresh.jsx
+++ b/client/src/components/PullToRefresh.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { usePullToRefresh } from "../hooks/usePullToRefresh";
+
+export default function PullToRefresh({ children, onRefresh, threshold = 70, maxPull = 120 }) {
+  const { pullDistance, isRefreshing, isPulling } = usePullToRefresh({
+    onRefresh,
+    threshold,
+    maxPull,
+  });
+
+  const progress = Math.min(pullDistance / threshold, 1);
+
+  return (
+    <div className="relative min-h-full">
+      {(isPulling || isRefreshing || pullDistance > 0) && (
+        <div
+          className="left-0 right-0 z-30 flex items-center justify-center pointer-events-none transition-all duration-150"
+          style={{
+            height: isRefreshing ? `${threshold}px` : `${pullDistance}px`,
+            opacity: isRefreshing ? 1 : Math.max(progress, 0.2),
+          }}
+        >
+          <div className="flex items-center gap-2 px-3 py-1.5 rounded-full bg-stone-900 text-white text-xs font-medium shadow-md">
+            <svg
+              className={`w-4 h-4 text-stone-200 ${isRefreshing ? "animate-spin" : ""}`}
+              style={{
+                transform: isRefreshing ? "none" : `rotate(${progress * 360}deg)`,
+              }}
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              {isRefreshing ? (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              ) : (
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M19 14l-7 7m0 0l-7-7m7 7V3"
+                />
+              )}
+            </svg>
+            <span>
+              {isRefreshing
+                ? "Refreshing..."
+                : progress >= 1
+                ? "Release to refresh"
+                : "Pull to refresh"}
+            </span>
+          </div>
+        </div>
+      )}
+      <div
+        className="transition-transform duration-100 ease-out"
+        style={{
+          transform:
+            pullDistance > 0 || isRefreshing
+              ? `translateY(${isRefreshing ? threshold : pullDistance}px)`
+              : "none",
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/usePullToRefresh.js
+++ b/client/src/hooks/usePullToRefresh.js
@@ -1,0 +1,77 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+
+export function usePullToRefresh({ onRefresh, threshold = 70, maxPull = 120 }) {
+  const [pullDistance, setPullDistance] = useState(0);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isPulling, setIsPulling] = useState(false);
+  const startYRef = useRef(0);
+  const isTopRef = useRef(false);
+
+  const handleTouchStart = useCallback((e) => {
+    if (window.scrollY <= 0 && e.touches.length === 1) {
+      startYRef.current = e.touches[0].clientY;
+      isTopRef.current = true;
+    } else {
+      isTopRef.current = false;
+    }
+  }, []);
+
+  const handleTouchMove = useCallback(
+    (e) => {
+      if (!isTopRef.current || isRefreshing) return;
+
+      const currentY = e.touches[0].clientY;
+      const diff = currentY - startYRef.current;
+
+      if (diff > 0 && window.scrollY <= 0) {
+        // Resistance curve for smooth feeling
+        const distance = Math.min(diff * 0.45, maxPull);
+        setPullDistance(distance);
+        setIsPulling(true);
+
+        // Prevent default overscroll bounce if pulling down
+        if (e.cancelable && diff > 10) {
+          e.preventDefault();
+        }
+      } else {
+        setPullDistance(0);
+        setIsPulling(false);
+      }
+    },
+    [isRefreshing, maxPull]
+  );
+
+  const handleTouchEnd = useCallback(async () => {
+    if (!isTopRef.current || isRefreshing) return;
+
+    if (pullDistance >= threshold && onRefresh) {
+      setIsRefreshing(true);
+      setPullDistance(threshold);
+      try {
+        await onRefresh();
+      } catch (err) {
+        console.error("Pull to refresh failed:", err);
+      } finally {
+        setIsRefreshing(false);
+      }
+    }
+
+    setPullDistance(0);
+    setIsPulling(false);
+    isTopRef.current = false;
+  }, [pullDistance, threshold, onRefresh, isRefreshing]);
+
+  useEffect(() => {
+    window.addEventListener("touchstart", handleTouchStart, { passive: true });
+    window.addEventListener("touchmove", handleTouchMove, { passive: false });
+    window.addEventListener("touchend", handleTouchEnd);
+
+    return () => {
+      window.removeEventListener("touchstart", handleTouchStart);
+      window.removeEventListener("touchmove", handleTouchMove);
+      window.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [handleTouchStart, handleTouchMove, handleTouchEnd]);
+
+  return { pullDistance, isRefreshing, isPulling, threshold };
+}

--- a/client/src/pages/AdminBugs.jsx
+++ b/client/src/pages/AdminBugs.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../auth/useAuth';
 import { getBugs, patchBugStatus } from '../utils/api/bugs';
 import Toast from '../components/Toast';
 import BugScreenshot from '../components/BugScreenshot';
+import PullToRefresh from '../components/PullToRefresh';
 
 const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
@@ -134,22 +135,25 @@ export default function AdminBugs() {
     }
   };
 
+  const fetchBugs = async () => {
+    if (!user) return;
+    try {
+      const token = await user.getIdToken();
+      const bugsData = await getBugs(token);
+      setBugs(bugsData);
+    } catch (err) {
+      console.error(err);
+      setError('Unable to load bug reports');
+    }
+  };
+
   useEffect(() => {
     if (loading || !user) return;
     let mounted = true;
     setLoadingBugs(true);
-    (async () => {
-      try {
-        const token = await user.getIdToken();
-        const bugsData = await getBugs(token);
-        if (mounted) setBugs(bugsData);
-      } catch (err) {
-        console.error(err);
-        setError('Unable to load bug reports');
-      } finally {
-        if (mounted) setLoadingBugs(false);
-      }
-    })();
+    fetchBugs().finally(() => {
+      if (mounted) setLoadingBugs(false);
+    });
     return () => { mounted = false; };
   }, [loading, user]);
 
@@ -285,28 +289,32 @@ export default function AdminBugs() {
 
           {/* Mobile card list */}
           <div className="md:hidden px-4 py-2">
-            {loadingBugs && (
-              [...Array(5)].map((_, i) => (
-                <div key={i} className="h-14 bg-stone-100 rounded-xl animate-pulse mb-3" />
-              ))
-            )}
-            {!loadingBugs && bugs.length === 0 && (
-              <div className="py-12 text-center">
-                <p className="text-3xl text-stone-200 mb-3">∅</p>
-                <p className="text-sm text-stone-400 mb-1">No bug reports found</p>
-                <p className="text-xs text-stone-300">Bug reports will appear here when users submit them</p>
+            <PullToRefresh onRefresh={fetchBugs}>
+              <div>
+                {loadingBugs && (
+                  [...Array(5)].map((_, i) => (
+                    <div key={i} className="h-14 bg-stone-100 rounded-xl animate-pulse mb-3" />
+                  ))
+                )}
+                {!loadingBugs && bugs.length === 0 && (
+                  <div className="py-12 text-center">
+                    <p className="text-3xl text-stone-200 mb-3">∅</p>
+                    <p className="text-sm text-stone-400 mb-1">No bug reports found</p>
+                    <p className="text-xs text-stone-300">Bug reports will appear here when users submit them</p>
+                  </div>
+                )}
+                {!loadingBugs && sortedBugs.map((bug, index) => (
+                  <BugMobileCard
+                    key={bug._id}
+                    bug={bug}
+                    index={index}
+                    onClick={() => { }} // Add navigation if you have a detail view
+                    onStatusClick={openMobilePicker}
+                    isUpdating={updatingIds.has(bug._id)}
+                  />
+                ))}
               </div>
-            )}
-            {!loadingBugs && sortedBugs.map((bug, index) => (
-              <BugMobileCard
-                key={bug._id}
-                bug={bug}
-                index={index}
-                onClick={() => { }} // Add navigation if you have a detail view
-                onStatusClick={openMobilePicker}
-                isUpdating={updatingIds.has(bug._id)}
-              />
-            ))}
+            </PullToRefresh>
 
             {mobilePicker && (
               <div className="fixed inset-x-0 bottom-0 z-50 bg-white border-t border-stone-200 p-4 md:hidden">

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -6,6 +6,7 @@ import { getAuthHeaders } from "../utils/getAuthHeaders";
 import { fmt } from "../utils/formatters";
 import CartDrawer from "../components/CartDrawer";
 import Stars from "../components/Stars";
+import PullToRefresh from "../components/PullToRefresh";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -89,6 +90,31 @@ export default function ProductPage() {
     }
   };
 
+  const fetchProductData = async () => {
+    try {
+      const res = await fetch(`${API}/api/products?all=true`);
+      if (!res.ok) throw new Error("Failed to load products");
+      const all = res.ok ? await res.json() : [];
+      const normalised = all.map(p => ({ ...p, id: p.productId }));
+      setProducts(normalised);
+      const found = normalised.find(p => String(p.productId) === String(productId));
+      if (!found) throw new Error("Product not found");
+      setProduct(found);
+      setRelated(
+        normalised
+          .filter(p => p.category === found.category && String(p.productId) !== String(productId))
+          .slice(0, 4)
+      );
+      const user = auth.currentUser;
+      if (user) {
+        const cartDoc = await apiGetCart(user.uid);
+        setCart(enrichCart(cartDoc, normalised));
+      }
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
   useEffect(() => {
     setVisible(false);
     setImgLoaded(false);
@@ -99,31 +125,9 @@ export default function ProductPage() {
     (async () => {
       setLoading(true);
       setError(null);
-      try {
-        const res = await fetch(`${API}/api/products?all=true`);
-        if (!res.ok) throw new Error("Failed to load products");
-        const all = res.ok ? await res.json() : [];
-        const normalised = all.map(p => ({ ...p, id: p.productId }));
-        setProducts(normalised);
-        const found = normalised.find(p => String(p.productId) === String(productId));
-        if (!found) throw new Error("Product not found");
-        setProduct(found);
-        setRelated(
-          normalised
-            .filter(p => p.category === found.category && String(p.productId) !== String(productId))
-            .slice(0, 4)
-        );
-        const user = auth.currentUser;
-        if (user) {
-          const cartDoc = await apiGetCart(user.uid);
-          setCart(enrichCart(cartDoc, normalised));
-        }
-      } catch (err) {
-        setError(err.message);
-      } finally {
-        setLoading(false);
-        setTimeout(() => setVisible(true), 80);
-      }
+      await fetchProductData();
+      setLoading(false);
+      setTimeout(() => setVisible(true), 80);
     })();
   }, [productId]);
 
@@ -242,7 +246,8 @@ export default function ProductPage() {
   return (
     <>
       <Shell cartCount={cartCount} onCartOpen={() => setCartOpen(true)}>
-        <style>{`
+        <PullToRefresh onRefresh={fetchProductData}>
+          <style>{`
           @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600&family=DM+Serif+Display:ital@0;1&display=swap');
           .pd-fade { opacity:0; transform:translateY(20px); transition:opacity .6s ease,transform .6s ease; }
           .pd-fade.in { opacity:1; transform:translateY(0); }
@@ -681,6 +686,7 @@ export default function ProductPage() {
             </div>
           </div>
         )}
+      </PullToRefresh>
       </Shell>
 
       <CartDrawer

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -12,6 +12,7 @@ import {
   getTransactionIcon,
 } from "../utils/rewardsUtils";
 import Navbar from "../components/Navbar";
+import PullToRefresh from "../components/PullToRefresh";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -193,30 +194,30 @@ const [rewardsError, setRewardsError] = useState("");
     }
   }, [activeTab]);
 
+  const fetchOrders = async () => {
+    const user = auth.currentUser;
+    if (!user) return;
+    
+    setLoadingOrders(true);
+    try {
+      const headers = await getAuthHeaders();
+      const res = await fetch(`${API}/api/orders/${user.uid}`, { headers, credentials: "include" });
+      if (!res.ok) throw new Error("Failed to load orders");
+      const data = await res.json();
+      setOrders(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err.message);
+      setOrders([]);
+    } finally {
+      setLoadingOrders(false);
+    }
+  };
+
   // Fetch orders when orders tab is active
   useEffect(() => {
-    if (activeTab !== "orders") return;
-    
-    const fetchOrders = async () => {
-      const user = auth.currentUser;
-      if (!user) return;
-      
-      setLoadingOrders(true);
-      try {
-        const headers = await getAuthHeaders();
-        const res = await fetch(`${API}/api/orders/${user.uid}`, { headers, credentials: "include" });
-        if (!res.ok) throw new Error("Failed to load orders");
-        const data = await res.json();
-        setOrders(Array.isArray(data) ? data : []);
-      } catch (err) {
-        setError(err.message);
-        setOrders([]);
-      } finally {
-        setLoadingOrders(false);
-      }
-    };
-
-    fetchOrders();
+    if (activeTab === "orders") {
+      fetchOrders();
+    }
   }, [activeTab]);
 
   const handleSaveProfile = async () => {
@@ -525,72 +526,74 @@ const [rewardsError, setRewardsError] = useState("");
 
         {/* ── ORDERS TAB ── */}
         {activeTab === "orders" && (
-          <div>
-            <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5">Order history</p>
+          <PullToRefresh onRefresh={fetchOrders}>
+            <div>
+              <p className="text-xs tracking-[0.2em] uppercase text-stone-400 mb-5">Order history</p>
 
-            {loadingOrders ? (
-              <div className="flex items-center justify-center py-10">
-                <span className="text-sm text-stone-400">Loading orders…</span>
-              </div>
-            ) : orders.length === 0 ? (
-              <div className="bg-white border border-stone-200 rounded-2xl p-10 text-center">
-                <p className="text-2xl mb-3">📦</p>
-                <p className="text-sm text-stone-500 mb-1">No orders yet.</p>
-                <p className="text-xs text-stone-400 mb-5">Start shopping to see your order history here.</p>
-                <button
-                  onClick={() => navigate("/home")}
-                  className="bg-stone-900 text-white text-sm px-6 py-2.5 rounded-full hover:bg-stone-700 transition-colors"
-                >
-                  Shop now
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {orders.map((order) => (
-                  <div key={order._id} className="bg-white border border-stone-200 rounded-2xl p-5 hover:border-stone-300 hover:shadow-sm transition-all">
-                    <div className="flex justify-between items-start gap-4 mb-3">
-                      <div className="flex-1">
-                        <p className="text-sm font-medium text-stone-900">
-                          {new Date(order.createdAt).toLocaleDateString('en-US', { 
-                            year: 'numeric', 
-                            month: 'long', 
-                            day: 'numeric' 
-                          })}
-                        </p>
-                        <p className="text-xs text-stone-400 mt-0.5">
-                          {order.items.length} item{order.items.length !== 1 ? 's' : ''}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-3">
-                        <div className="text-right">
-                          <p className="text-sm font-medium text-stone-900">₹{order.total.toFixed(2)}</p>
-                          <span className={`text-[10px] tracking-widest uppercase px-2.5 py-1 rounded-full ${
-                            order.status === 'paid' 
-                              ? 'bg-green-50 text-green-700' 
-                              : order.status === 'failed'
-                              ? 'bg-red-50 text-red-700'
-                              : 'bg-stone-100 text-stone-600'
-                          }`}>
-                            {order.status}
-                          </span>
+              {loadingOrders ? (
+                <div className="flex items-center justify-center py-10">
+                  <span className="text-sm text-stone-400">Loading orders…</span>
+                </div>
+              ) : orders.length === 0 ? (
+                <div className="bg-white border border-stone-200 rounded-2xl p-10 text-center">
+                  <p className="text-2xl mb-3">📦</p>
+                  <p className="text-sm text-stone-500 mb-1">No orders yet.</p>
+                  <p className="text-xs text-stone-400 mb-5">Start shopping to see your order history here.</p>
+                  <button
+                    onClick={() => navigate("/home")}
+                    className="bg-stone-900 text-white text-sm px-6 py-2.5 rounded-full hover:bg-stone-700 transition-colors"
+                  >
+                    Shop now
+                  </button>
+                </div>
+              ) : (
+                <div className="space-y-3">
+                  {orders.map((order) => (
+                    <div key={order._id} className="bg-white border border-stone-200 rounded-2xl p-5 hover:border-stone-300 hover:shadow-sm transition-all">
+                      <div className="flex justify-between items-start gap-4 mb-3">
+                        <div className="flex-1">
+                          <p className="text-sm font-medium text-stone-900">
+                            {new Date(order.createdAt).toLocaleDateString('en-US', { 
+                              year: 'numeric', 
+                              month: 'long', 
+                              day: 'numeric' 
+                            })}
+                          </p>
+                          <p className="text-xs text-stone-400 mt-0.5">
+                            {order.items.length} item{order.items.length !== 1 ? 's' : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-3">
+                          <div className="text-right">
+                            <p className="text-sm font-medium text-stone-900">₹{order.total.toFixed(2)}</p>
+                            <span className={`text-[10px] tracking-widest uppercase px-2.5 py-1 rounded-full ${
+                              order.status === 'paid' 
+                                ? 'bg-green-50 text-green-700' 
+                                : order.status === 'failed'
+                                ? 'bg-red-50 text-red-700'
+                                : 'bg-stone-100 text-stone-600'
+                            }`}>
+                              {order.status}
+                            </span>
+                          </div>
                         </div>
                       </div>
-                    </div>
 
-                    {/* Order items list */}
-                    <div className="pt-3 border-t border-stone-100 space-y-1.5">
-                      {order.items.map((item, idx) => (
-                        <div key={idx} className="flex justify-between text-xs text-stone-600">
-                          <span>Product ID {item.productId} × {item.quantity}</span>
-                          <span className="text-stone-900">₹{(item.price * item.quantity).toFixed(2)}</span>
-                        </div>
-                      ))}
+                      {/* Order items list */}
+                      <div className="pt-3 border-t border-stone-100 space-y-1.5">
+                        {order.items.map((item, idx) => (
+                          <div key={idx} className="flex justify-between text-xs text-stone-600">
+                            <span>Product ID {item.productId} × {item.quantity}</span>
+                            <span className="text-stone-900">₹{(item.price * item.quantity).toFixed(2)}</span>
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </PullToRefresh>
         )}
       </div>
 


### PR DESCRIPTION
## 📝 What does this PR do?
Implements a lightweight, native touch 'Pull to Refresh' gesture across mobile list views (Profile Orders tab, Admin Bugs directory, and Product Page) using a custom hook and indicator component.

## 🔗 Related Issue
Closes #895

## 🧪 How was this tested?
- Tested touch gestures (`touchstart`, `touchmove`, `touchend`) with pull resistance curve in responsive touch emulation mode.
- Verified loading indicator spinner states and data refetching.
- Verified production build via `npm run build` in `client`.

## 📸 Screenshots (if UI changes)
N/A

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys