### PR TITLE
refactor: unify NotesPage form validation with react-hook-form and Zod

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
                 "@fullcalendar/daygrid": "^6.1.21",
                 "@fullcalendar/interaction": "^6.1.21",
                 "@fullcalendar/react": "^6.1.20",
+                "@hookform/resolvers": "^5.7.1",
                 "@tailwindcss/vite": "^4.0.0",
                 "@tanstack/react-query": "^5.101.4",
                 "dompurify": "^3.4.12",
@@ -19,9 +20,11 @@
                 "marked": "^18.0.7",
                 "react": "^19.2.8",
                 "react-dom": "^19.2.8",
+                "react-hook-form": "^7.84.0",
                 "react-router-dom": "^7.18.1",
                 "recharts": "^3.10.0",
-                "tailwindcss": "^4.0.0"
+                "tailwindcss": "^4.0.0",
+                "zod": "^3.25.76"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.1",
@@ -173,6 +176,23 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/@eslint/eslintrc/node_modules/globals": {
             "version": "14.0.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -185,6 +205,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@eslint/js": {
             "version": "9.39.5",
@@ -902,6 +929,116 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@hookform/resolvers": {
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.7.1.tgz",
+            "integrity": "sha512-8wS/P4UDr5sQDe4nFaV51TVyfDPrWgNIXweqG0Bs9Z5LSuzKLb+RQNPvkN2oHM5SRrJyWrVH/F+LOUcFjUyvwQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/utils": "^0.3.0"
+            },
+            "peerDependencies": {
+                "@sinclair/typebox": ">=0.25.24",
+                "@standard-schema/spec": "^1.0.0",
+                "@typeschema/main": ">=0.13.7",
+                "@vinejs/vine": "^2.0.0 || ^3.0.0 || ^4.0.0",
+                "ajv": "^8.12.0",
+                "ajv-errors": "^3.0.0",
+                "ajv-formats": "^2.1.1",
+                "arktype": "^2.0.0",
+                "ata-validator": "^1.2.0",
+                "class-transformer": ">=0.4.0",
+                "class-validator": ">=0.12.0",
+                "computed-types": "^1.0.0",
+                "effect": "^3.10.3",
+                "fluentvalidation-ts": "^3.0.0",
+                "fp-ts": "^2.7.0",
+                "io-ts": "^2.0.0",
+                "joi": "^17.0.0",
+                "nope-validator": ">=0.12.0",
+                "react-hook-form": "^7.55.0",
+                "superstruct": ">=0.12.0",
+                "typanion": "^3.3.2",
+                "valibot": ">=0.31.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+                "vest": ">=3.0.0",
+                "yup": "^1.0.0",
+                "zod": "^3.25.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@sinclair/typebox": {
+                    "optional": true
+                },
+                "@standard-schema/spec": {
+                    "optional": true
+                },
+                "@typeschema/main": {
+                    "optional": true
+                },
+                "@vinejs/vine": {
+                    "optional": true
+                },
+                "ajv": {
+                    "optional": true
+                },
+                "ajv-errors": {
+                    "optional": true
+                },
+                "ajv-formats": {
+                    "optional": true
+                },
+                "arktype": {
+                    "optional": true
+                },
+                "ata-validator": {
+                    "optional": true
+                },
+                "class-transformer": {
+                    "optional": true
+                },
+                "class-validator": {
+                    "optional": true
+                },
+                "computed-types": {
+                    "optional": true
+                },
+                "effect": {
+                    "optional": true
+                },
+                "fluentvalidation-ts": {
+                    "optional": true
+                },
+                "fp-ts": {
+                    "optional": true
+                },
+                "io-ts": {
+                    "optional": true
+                },
+                "joi": {
+                    "optional": true
+                },
+                "nope-validator": {
+                    "optional": true
+                },
+                "superstruct": {
+                    "optional": true
+                },
+                "typanion": {
+                    "optional": true
+                },
+                "valibot": {
+                    "optional": true
+                },
+                "vest": {
+                    "optional": true
+                },
+                "yup": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1196,9 +1333,6 @@
             "cpu": [
                 "arm64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1214,9 +1348,6 @@
             "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
             "cpu": [
                 "arm64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1234,9 +1365,6 @@
             "cpu": [
                 "ppc64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1252,9 +1380,6 @@
             "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
             "cpu": [
                 "s390x"
-            ],
-            "libc": [
-                "glibc"
             ],
             "license": "MIT",
             "optional": true,
@@ -1272,9 +1397,6 @@
             "cpu": [
                 "x64"
             ],
-            "libc": [
-                "glibc"
-            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -1290,9 +1412,6 @@
             "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
             "cpu": [
                 "x64"
-            ],
-            "libc": [
-                "musl"
             ],
             "license": "MIT",
             "optional": true,
@@ -1909,16 +2028,17 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-            "dev": true,
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -2431,6 +2551,30 @@
                 "url": "https://eslint.org/donate"
             }
         },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/espree": {
             "version": "10.4.0",
             "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -2505,7 +2649,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
@@ -2521,6 +2665,24 @@
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/fast-uri": {
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true
         },
         "node_modules/faye-websocket": {
             "version": "0.11.4",
@@ -2877,11 +3039,12 @@
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
-            "license": "MIT"
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -3489,6 +3652,22 @@
                 "react": "^19.2.8"
             }
         },
+        "node_modules/react-hook-form": {
+            "version": "7.84.0",
+            "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.84.0.tgz",
+            "integrity": "sha512-+hWvQP6GLco56mDwrbU4XnHix8t1z90ltZsDIrREl+jnQFQxYLX8oAzqe/Xn8nHpmoXTY5M6oEXrAhbP1qevNQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/react-hook-form"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17 || ^18 || ^19"
+            }
+        },
         "node_modules/react-is": {
             "version": "19.2.4",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.4.tgz",
@@ -3607,6 +3786,17 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
             "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4079,6 +4269,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/client/package.json
+++ b/client/package.json
@@ -13,17 +13,20 @@
         "@fullcalendar/daygrid": "^6.1.21",
         "@fullcalendar/interaction": "^6.1.21",
         "@fullcalendar/react": "^6.1.20",
-        "@tanstack/react-query": "^5.101.4",
+        "@hookform/resolvers": "^5.7.1",
         "@tailwindcss/vite": "^4.0.0",
+        "@tanstack/react-query": "^5.101.4",
         "dompurify": "^3.4.12",
         "firebase": "^12.16.0",
         "framer-motion": "^12.42.2",
         "marked": "^18.0.7",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
+        "react-hook-form": "^7.84.0",
         "react-router-dom": "^7.18.1",
         "recharts": "^3.10.0",
-        "tailwindcss": "^4.0.0"
+        "tailwindcss": "^4.0.0",
+        "zod": "^3.25.76"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",

--- a/client/src/pages/NotesPage.jsx
+++ b/client/src/pages/NotesPage.jsx
@@ -1,6 +1,9 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
 import Navbar from "../components/Navbar";
+import { workoutLogSchema } from "../utils/formSchemas";
 import { getWorkoutByDate, saveWorkout, removeExerciseFromWorkout } from "../utils/workoutStorage";
 
 /**
@@ -12,12 +15,21 @@ import { getWorkoutByDate, saveWorkout, removeExerciseFromWorkout } from "../uti
 export default function NotesPage() {
   const navigate = useNavigate();
   const [date, setDate] = useState("");
-  const [title, setTitle] = useState("");
-  const [notes, setNotes] = useState("");
   const [exercises, setExercises] = useState([]);
   const [error, setError] = useState("");
   const [saved, setSaved] = useState(false);
   const [imageErrors, setImageErrors] = useState(new Set());
+
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    reset,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(workoutLogSchema),
+    defaultValues: { date: "", title: "", notes: "" },
+  });
 
   useEffect(() => {
     // Get selectedDate from localStorage
@@ -27,29 +39,27 @@ export default function NotesPage() {
       return;
     }
     setDate(storedDate);
+    // Set the date synchronously so the form is never submitted with an
+    // empty date while the stored workout is still loading.
+    reset({ date: storedDate });
 
     // Pre-fill if data exists
     getWorkoutByDate(storedDate).then(workout => {
-      if (workout) {
-        setTitle(workout.title || "");
-        setNotes(workout.notes || "");
-        setExercises(workout.exercises || []);
-      }
+      reset({
+        date: storedDate,
+        title: workout?.title || "",
+        notes: workout?.notes || "",
+      });
+      setExercises(workout?.exercises || []);
     });
-  }, []);
+  }, [reset]);
 
-  const handleSave = async () => {
-    // Prevent saving empty title
-    if (!title.trim()) {
-      alert("Please enter a workout title.");
-      return;
-    }
-
+  const handleSave = async (data) => {
     // Create entry object
     const entry = {
-      date,
-      title,
-      notes,
+      date: data.date,
+      title: data.title,
+      notes: data.notes,
       exercises,
     };
 
@@ -64,9 +74,11 @@ export default function NotesPage() {
   };
 
   const handleAddExercise = async () => {
-    // Save draft state to backend
+    // Save draft state to backend (title/notes may be empty at this point)
+    const title = getValues("title");
+    const notes = getValues("notes");
     await saveWorkout({ date, title: title || "", notes: notes || "", exercises });
-    
+
     // Determine suggested category
     const combinedText = `${title} ${notes}`.toLowerCase();
     let suggestedCategory = "chest"; // default
@@ -133,35 +145,46 @@ export default function NotesPage() {
             <h1 className="font-['DM_Serif_Display'] text-2xl sm:text-3xl md:text-4xl text-stone-900">{formattedDate}</h1>
           </header>
 
-          <div className="space-y-8">
+          <form onSubmit={handleSubmit(handleSave)} className="space-y-8" noValidate>
             {/* Input field for "Workout Title" */}
             <div>
-              <label className="block text-xs text-stone-500 mb-2 tracking-wide uppercase">
+              <label htmlFor="workout-title" className="block text-xs text-stone-500 mb-2 tracking-wide uppercase">
                 Workout Title
               </label>
               <input
+                id="workout-title"
                 type="text"
-                value={title}
-                onChange={(e) => setTitle(e.target.value)}
                 placeholder="e.g. Chest Day"
-                className="w-full border-b border-stone-200 bg-transparent py-3 text-2xl sm:text-3xl md:text-4xl text-stone-900 
-                           font-['DM_Serif_Display'] placeholder-stone-200 focus:outline-none focus:border-stone-900 transition-colors"
+                aria-invalid={errors.title ? true : undefined}
+                aria-describedby={errors.title ? "workout-title-error" : undefined}
+                className={`w-full border-b bg-transparent py-3 text-2xl sm:text-3xl md:text-4xl text-stone-900
+                           font-['DM_Serif_Display'] placeholder-stone-200 focus:outline-none transition-colors
+                           ${errors.title
+                    ? "border-red-400 focus:border-red-500"
+                    : "border-stone-200 focus:border-stone-900"
+                  }`}
+                {...register("title")}
               />
+              {errors.title && (
+                <p id="workout-title-error" role="alert" className="text-xs text-red-600 mt-2">
+                  {errors.title.message}
+                </p>
+              )}
             </div>
 
             {/* Textarea for "Workout Notes" */}
             <div>
-              <label className="block text-xs text-stone-500 mb-2 tracking-wide uppercase">
+              <label htmlFor="workout-notes" className="block text-xs text-stone-500 mb-2 tracking-wide uppercase">
                 Workout Notes
               </label>
               <textarea
-                value={notes}
-                onChange={(e) => setNotes(e.target.value)}
+                id="workout-notes"
                 placeholder="List exercises, weight, reps..."
                 rows={12}
-                className="w-full border border-stone-200 bg-white rounded-xl sm:rounded-2xl px-4 sm:px-6 py-4 sm:py-6 text-sm sm:text-base text-stone-700 
+                className="w-full border border-stone-200 bg-white rounded-xl sm:rounded-2xl px-4 sm:px-6 py-4 sm:py-6 text-sm sm:text-base text-stone-700
                            placeholder-stone-300 focus:outline-none focus:border-stone-900 transition-colors resize-none
                            min-h-75 sm:min-h-112.5 leading-relaxed"
+                {...register("notes")}
               />
             </div>
 
@@ -226,6 +249,7 @@ export default function NotesPage() {
                         </div>
 
                         <button
+                          type="button"
                           onClick={() => handleRemoveExercise(exercise.id)}
                           className="text-xs text-stone-500 hover:text-stone-700 font-medium uppercase tracking-wide transition-colors"
                         >
@@ -240,6 +264,7 @@ export default function NotesPage() {
 
             {/* Add Exercise Button */}
             <button
+              type="button"
               onClick={handleAddExercise}
               className="w-full bg-stone-100 text-stone-900 text-sm py-4 rounded-full hover:bg-stone-900 hover:text-white transition-all font-medium border border-stone-200 hover:border-stone-900 active:scale-95"
             >
@@ -248,13 +273,13 @@ export default function NotesPage() {
 
             {/* Save Button */}
             <button
-              onClick={handleSave}
+              type="submit"
               className={`w-full text-sm py-4 rounded-full transition-all font-medium
                          ${saved ? "bg-stone-700 text-stone-300" : "bg-stone-900 text-white hover:bg-stone-700 shadow-lg shadow-stone-200/50"}`}
             >
               {saved ? "Saved ✓" : "Save Workout"}
             </button>
-          </div>
+          </form>
         </div>
       </main>
     </div>

--- a/client/src/utils/formSchemas.js
+++ b/client/src/utils/formSchemas.js
@@ -1,0 +1,36 @@
+// Client-side Zod schemas for frontend forms.
+//
+// These mirror the backend validation in server/validation/requestSchemas.js so
+// users get the same rules and error messages before the request ever hits the
+// API. If client and server ever move into a shared package, these can be
+// extracted to a single source of truth.
+import { z } from "zod";
+
+const workoutExerciseSchema = z
+  .object({
+    id: z.string().min(1, "id is required"),
+    name: z.string().min(1, "name is required"),
+    bodyPart: z.string().optional(),
+    target: z.string().optional(),
+    equipment: z.string().optional(),
+    gifUrl: z.string().optional(),
+  })
+  .strict();
+
+// Mirrors the backend `workoutLogBodySchema`, with one intentional difference:
+// the UI requires a workout title before saving (the backend keeps `title`
+// optional so stored drafts never fail server-side), so we enforce it here.
+//
+// Note: exercise entries are picked via a separate flow and are not part of the
+// react-hook-form fields on NotesPage, so they are merged in after validation
+// and validated by the backend on save (as before this refactor).
+export const workoutLogSchema = z
+  .object({
+    date: z
+      .string()
+      .min(1, "No date selected. Please go back to the calendar and select a date."),
+    title: z.string().trim().min(1, "Please enter a workout title."),
+    notes: z.string().optional(),
+    exercises: z.array(workoutExerciseSchema).optional(),
+  })
+  .strict();


### PR DESCRIPTION
Closes #907

## Summary

Installs react-hook-form with the Zod resolver and refactors the Workout Notes form (NotesPage) to validate through a shared-style Zod schema, replacing the manual `useState` tracking and the `alert()` check.

## Changes

- **client/package.json / package-lock.json**: add `react-hook-form`, `@hookform/resolvers`, and `zod`
- **client/src/utils/formSchemas.js (NEW)**: `workoutLogSchema` mirrors the backend `workoutLogBodySchema` in `server/validation/requestSchemas.js`. One intentional difference: the UI requires a workout title before saving (the backend keeps it optional so stored drafts never fail server-side). If client and server converge into a shared package, these schemas can be extracted to one source of truth
- **client/src/pages/NotesPage.jsx (UPDATED)**:
  - `useForm({ resolver: zodResolver(workoutLogSchema) })` replaces `title`/`notes` `useState`
  - `alert("Please enter a workout title.")` replaced with an accessible inline error (`role="alert"`, `aria-invalid`, `aria-describedby`)
  - Card wrapped in a real `<form noValidate>` so Enter submits; non-submit actions (Add Exercise, Remove) are `type="button"`
  - Date is reset synchronously so the form can never submit with an empty date while the stored workout is loading
  - Draft save on "Add Your Exercise" preserved via `getValues()`

## Validation

- `vite build` passes (1144 modules)
- Behavior preserved: draft saves, suggested exercise category, and the 1s confirmation redirect before navigating to /tracker