### PR TITLE
fix(ui): add lazy loading to product images

### DIFF
--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -196,14 +196,15 @@ function CartDrawer({
                                   border border-stone-200">
                     {item.image ? (
                       <img
-                        src={item.image}
-                        alt={item.name}
-                        className="w-full h-full object-cover"
-                        onError={(e) => {
-                          e.currentTarget.onerror = null;
-                          e.currentTarget.style.display = "none";
-                        }}
-                      />
+  src={item.image}
+  alt={item.name}
+  loading="lazy"
+  className="w-full h-full object-cover"
+  onError={(e) => {
+    e.currentTarget.onerror = null;
+    e.currentTarget.style.display = "none";
+  }}
+/>
                     ) : (
                       <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
                         stroke="#d6d3d1" strokeWidth="1.5"

--- a/client/src/pages/ProductPage.jsx
+++ b/client/src/pages/ProductPage.jsx
@@ -636,8 +636,12 @@ export default function ProductPage() {
                     >
                       <div className="relative bg-stone-100 aspect-square overflow-hidden">
                         {rel.image ? (
-                          <img src={rel.image} alt={rel.name}
-                            className="related-img w-full h-full object-cover" />
+                         <img
+  src={rel.image}
+  alt={rel.name}
+  loading="lazy"
+  className="related-img w-full h-full object-cover"
+/>
                         ) : (
                           <div className="w-full h-full flex items-center justify-center
                                           text-4xl opacity-20">


### PR DESCRIPTION
## 🔗 Related Issue
 #911

## 🧪 How was this tested?
- Verified the application runs locally.
- Opened the Product page and confirmed related product images render correctly.
- Opened the Cart Drawer and confirmed product images render correctly.
- Verified that adding `loading="lazy"` does not affect image loading or functionality.


## ✅ Checklist
- I've read the CONTRIBUTING guide
-My code follows the project's style guidelines
-  I've tested my changes locally
-I've linked the related issue
- I haven't introduced any new secrets or API keys