### PR TITLE
feat: add Admin KPI skeleton loader

### DIFF
--- a/client/src/components/AdminKPIGrid.jsx
+++ b/client/src/components/AdminKPIGrid.jsx
@@ -27,6 +27,21 @@ const KPICard = ({ label, value, sub, icon }) => (
   </div>
 );
 
+
+export function AdminKPIGridSkeleton() {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 md:gap-5">
+      {[...Array(4)].map((_, i) => (
+        <div
+          key={i}
+          className="bg-stone-100 rounded-2xl animate-pulse h-28 sm:h-36"
+        />
+      ))}
+    </div>
+  );
+}
+
+
 export default function AdminKPIGrid({ stats }) {
   if (!stats) return null;
 

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -2,7 +2,7 @@
 // src/pages/AdminDashboard.jsx
 import { useState, useEffect } from "react";
 import AdminNavbar from "../components/AdminNavbar";
-import AdminKPIGrid from "../components/AdminKPIGrid";
+import AdminKPIGrid, {AdminKPIGridSkeleton} from "../components/AdminKPIGrid";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
 import {
   AreaChart, Area,
@@ -258,9 +258,7 @@ export default function AdminDashboard() {
 
         {loading && (
           <div className="space-y-4 sm:space-y-5">
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 md:gap-5">
-              {[...Array(4)].map((_, i) => <Skeleton key={i} className="h-28 sm:h-36" />)}
-            </div>
+            <AdminKPIGridSkeleton />
             <div className="grid md:grid-cols-2 gap-4 sm:gap-5">
               <Skeleton className="h-60 sm:h-72" />
               <Skeleton className="h-60 sm:h-72" />


### PR DESCRIPTION
## 📋 What does this PR do?
Adds a skeleton loading state for the Admin KPI Grid to prevent layout shifts while dashboard data is loading.

- Added `AdminKPIGridSkeleton` with 4 pulsating placeholder cards.
- Used Tailwind CSS `animate-pulse` and `bg-stone-100`.
- Updated `AdminDashboard.jsx` to display the skeleton while dashboard data is loading.


## 🔗 Related Issue
Closes #923 

## 🧪 How was this tested?
- Verified the skeleton component structure.
- Verified the loading state integration in `AdminDashboard.jsx`.


## ✅ Checklist
- [✅] I've read the CONTRIBUTING guide
- [✅] My code follows the project's style guidelines
- [✅] I've linked the related issue
- [✅] I haven't introduced any new secrets or API keys