### PR TITLE
fix: implement graceful shutdown for Express server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -199,7 +199,27 @@ app.use((err, req, res, next) => {
   res.status(500).json({ error: "Something went wrong" });
 });
 
-app.listen(port, () => {
+const mongoose = require("mongoose");
+
+const server = app.listen(port, () => {
   console.log(`Server listening on port ${port}`);
   console.log(`CORS allowed origins: ${allowedOrigins.join(", ")}`);
 });
+
+// ── Graceful Shutdown ─────────────────────────────────────────────────────────
+const shutdown = async (signal) => {
+  console.log(`\n${signal} received. Shutting down gracefully...`);
+  server.close(async () => {
+    try {
+      await mongoose.connection.close();
+      console.log("MongoDB connection closed.");
+      process.exit(0);
+    } catch (err) {
+      console.error("Error during shutdown:", err.message);
+      process.exit(1);
+    }
+  });
+};
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));


### PR DESCRIPTION
## 📋 What does this PR do?

Updates `server/index.js` to handle `SIGTERM` and `SIGINT` signals 
gracefully instead of killing the process instantly.

When a shutdown signal is received:
1. Stops accepting new incoming requests (`server.close()`)
2. Waits for existing in-flight HTTP requests to finish
3. Cleanly closes the MongoDB connection (`mongoose.connection.close()`)
4. Exits the process cleanly (`process.exit(0)`)

## 🔗 Related Issue
Closes #940

## 🛠️ Changes Made
- `server/index.js` — stored server instance in a variable and added 
graceful shutdown handler for `SIGTERM` and `SIGINT` signals

## ✅ Benefits
- Prevents data corruption during deployments
- Prevents users getting abrupt 502 errors during server restarts
- Required for zero-downtime deployments and Docker scaling

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys