### PR TITLE
security: enforce HTTPS with HSTS via Helmet

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -105,7 +105,20 @@ app.use(
   }),
 );
 
-app.use(helmet());
+// Enforce HTTPS with HSTS: browsers will only connect over a secure
+// connection for a full year (including subdomains), preventing MITM
+// downgrade attacks. The preload flag opts this domain into the HSTS
+// preload list (requires prior submission to hstspreload.org).
+// Browsers ignore the header over plain HTTP, so this is safe in dev too.
+app.use(
+  helmet({
+    strictTransportSecurity: {
+      maxAge: 31536000, // 1 year in seconds
+      includeSubDomains: true,
+      preload: true,
+    },
+  }),
+);
 app.use(express.json({ limit: "10kb" }));
 app.use(express.urlencoded({ extended: true, limit: "10kb" }));
 // Disable automatic ETag generation to avoid conditional 304 responses


### PR DESCRIPTION
Closes #950

## Summary

Explicitly configures HTTP Strict Transport Security (HSTS) in the Express server so browsers refuse to connect to the API over plain HTTP, blocking MITM downgrade attacks.

## Changes

- `server/index.js`: replaced the default `app.use(helmet())` HSTS settings (180-day max-age) with an explicit `strictTransportSecurity` config: `maxAge: 31536000` (1 year), `includeSubDomains: true`, and `preload: true`.

## Resulting header

Verified against a live server:

```
Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
```

## Notes

- Browsers only honor the header over HTTPS, so this is safe in dev (plain HTTP) too.
- `preload: true` opts the domain into the HSTS preload list; the domain must also be submitted to https://hstspreload.org before preload takes effect.

## Validation

- Backend test suite passes (78 tests, 3 suites)
- Verified the exact header value with an in-memory Express server