### PR TITLE
fix: trap keyboard focus inside CartDrawer and all modals

### DIFF
--- a/client/src/components/CartDrawer.jsx
+++ b/client/src/components/CartDrawer.jsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef } from "react";
 import { fmt } from "../utils/formatters";
 import { Link } from "react-router-dom";
+import useFocusTrap from "../hooks/useFocusTrap";
 
 function CartDrawer({
   isOpen,
@@ -15,75 +16,14 @@ function CartDrawer({
   // Refs for focus management
   const drawerRef = useRef(null);
   const closeButtonRef = useRef(null);
-  const triggerElementRef = useRef(null);
 
-  // Handle Escape key and focus trapping
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e) => {
-      // Close drawer on Escape
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-        return;
-      }
-
-      // Focus trap: Tab and Shift+Tab cycle through focusable elements
-      if (e.key === "Tab") {
-        const focusableElements = drawerRef.current?.querySelectorAll(
-          "button, [href], input, [tabindex]:not([tabindex='-1'])"
-        );
-
-        if (!focusableElements || focusableElements.length === 0) return;
-
-        const focusableArray = Array.from(focusableElements);
-        const currentIndex = focusableArray.indexOf(document.activeElement);
-
-        if (e.shiftKey) {
-          // Shift+Tab: move focus backward
-          if (currentIndex <= 0) {
-            e.preventDefault();
-            focusableArray[focusableArray.length - 1].focus();
-          }
-        } else {
-          // Tab: move focus forward
-          if (currentIndex >= focusableArray.length - 1) {
-            e.preventDefault();
-            focusableArray[0].focus();
-          }
-        }
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  // Focus management: Save trigger element and manage focus on open/close
-  useEffect(() => {
-    if (isOpen) {
-      // Save the element that triggered the drawer (currently focused element)
-      triggerElementRef.current = document.activeElement;
-
-      // Move focus to close button or first focusable element in drawer
-      setTimeout(() => {
-        if (closeButtonRef.current) {
-          closeButtonRef.current.focus();
-        } else {
-          const firstFocusable = drawerRef.current?.querySelector(
-            "button, [href], input, [tabindex]:not([tabindex='-1'])"
-          );
-          firstFocusable?.focus();
-        }
-      }, 0);
-    } else {
-      // Restore focus to trigger element when drawer closes
-      if (triggerElementRef.current && typeof triggerElementRef.current.focus === "function") {
-        triggerElementRef.current.focus();
-      }
-    }
-  }, [isOpen]);
+  // Trap keyboard focus inside the drawer while it is open: Tab/Shift+Tab
+  // cycle within the drawer, Escape closes it, focus moves to the close
+  // button on open, and returns to the triggering element on close.
+  useFocusTrap(drawerRef, isOpen, {
+    initialFocusRef: closeButtonRef,
+    onEscape: onClose,
+  });
 
   // Prevent body scroll when drawer is open
   useEffect(() => {
@@ -111,6 +51,7 @@ function CartDrawer({
         aria-modal="true"
         aria-labelledby="cart-drawer-title"
         aria-hidden={!isOpen}
+        inert={!isOpen ? true : undefined}
         className={`cart-slide fixed right-0 top-0 h-full z-50 shadow-2xl flex flex-col
                     bg-white w-full sm:max-w-sm ${isOpen ? "open" : ""}`}
       >

--- a/client/src/components/FitnessChatBot.jsx
+++ b/client/src/components/FitnessChatBot.jsx
@@ -2,6 +2,7 @@
 import { useState, useEffect, useRef } from "react";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
+import useFocusTrap from "../hooks/useFocusTrap";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
 
@@ -49,6 +50,7 @@ export default function FitnessChatBot() {
   const inputRef = useRef(null);
   const historyRef = useRef([]);
   const fabRef = useRef(null);
+  const chatWindowRef = useRef(null);
 
   useEffect(() => {
     const t = setTimeout(() => setVisible(true), 120);
@@ -67,10 +69,6 @@ export default function FitnessChatBot() {
       `Fitness assistant: ${latestMessage.text.replace(/\*\*|__/g, "")}`,
     );
   }, [msgs]);
-
-  useEffect(() => {
-    if (open) setTimeout(() => inputRef.current?.focus(), 200);
-  }, [open]);
 
   // Prevent body scroll on mobile when chat is open
   useEffect(() => {
@@ -182,12 +180,13 @@ export default function FitnessChatBot() {
     window.requestAnimationFrame(() => fabRef.current?.focus());
   };
 
-  const onChatKeyDown = (e) => {
-    if (e.key === "Escape") {
-      e.stopPropagation();
-      closeChat();
-    }
-  };
+  // Trap keyboard focus inside the chat window while open: Tab/Shift+Tab
+  // cycle within the dialog, Escape closes it (closeChat restores focus to
+  // the FAB), and focus moves to the message input on open.
+  useFocusTrap(chatWindowRef, open, {
+    initialFocusRef: inputRef,
+    onEscape: closeChat,
+  });
 
   return (
     <>
@@ -281,12 +280,12 @@ export default function FitnessChatBot() {
       {/* ── Chat Window ── */}
       {/* Full-screen on mobile, fixed-size floating window on sm+ */}
       <div
+        ref={chatWindowRef}
         id="fitness-chatbot-dialog"
         role="dialog"
         aria-labelledby="fitness-chatbot-title"
         aria-hidden={!open}
         inert={!open ? true : undefined}
-        onKeyDown={onChatKeyDown}
         className={`fm-chat-window fixed z-50 bg-white border border-stone-200
                   shadow-2xl flex flex-col overflow-hidden
                   /* Mobile: full screen minus FAB area */

--- a/client/src/components/NearbyFitnessCenters.jsx
+++ b/client/src/components/NearbyFitnessCenters.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import useFocusTrap from "../hooks/useFocusTrap";
 import FitnessCenterDetail from "./FitnessCenterDetail";
 
 const API = import.meta.env.VITE_API_URL || "http://localhost:5000";
@@ -29,6 +30,14 @@ export default function NearbyFitnessCenters({ visible = true }) {
   const [filter, setFilter] = useState("all");
   const [selected, setSelected] = useState(null);
   const [modalOpen, setModalOpen] = useState(false);
+  const modalRef = useRef(null);
+
+  // Trap keyboard focus inside the fitness center detail modal while open:
+  // Tab/Shift+Tab cycle within the modal, Escape closes it, focus moves to
+  // the close button on open and returns to the card that opened it on close.
+  useFocusTrap(modalRef, modalOpen && !!selected, {
+    onEscape: () => setModalOpen(false),
+  });
 
   useEffect(() => {
     (async () => {
@@ -121,7 +130,13 @@ export default function NearbyFitnessCenters({ visible = true }) {
         CSS transform stacking context created by the fade-in animation.
         This ensures the backdrop covers the full viewport. */}
     {modalOpen && selected && createPortal(
-      <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-10">
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${selected.name} details`}
+        className="fixed inset-0 z-50 flex items-center justify-center px-4 py-10"
+      >
         {/* Fix 1: backdrop is now fixed (not absolute) — covers full viewport */}
         <div
           className="fixed inset-0 bg-black/40 backdrop-blur-sm"

--- a/client/src/components/ReportBugButton.jsx
+++ b/client/src/components/ReportBugButton.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAuth } from '../auth/useAuth';
+import useFocusTrap from '../hooks/useFocusTrap';
 
 const API = import.meta.env.VITE_API_URL || 'http://localhost:5000';
 
@@ -151,6 +152,7 @@ export default function ReportBugButton() {
   const [imgError, setImgError]       = useState('');
 
   const fileInputRef = useRef(null);
+  const formRef = useRef(null);
   const pageUrl = typeof window !== 'undefined' ? window.location.pathname : '/';
 
   const dismissToast = useCallback(() => setToast(null), []);
@@ -170,13 +172,10 @@ export default function ReportBugButton() {
   const openModal  = () => { resetForm(); setOpen(true); };
   const closeModal = () => { if (loading) return; setOpen(false); };
 
-  // Escape to close
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e) => { if (e.key === 'Escape') closeModal(); };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, loading]);
+  // Trap keyboard focus inside the bug report modal while open: Tab/Shift+Tab
+  // cycle within the panel, Escape closes it, focus moves to the close button
+  // on open and returns to the trigger on close.
+  useFocusTrap(formRef, open, { onEscape: closeModal });
 
   // Handle screenshot pick
   const onFileChange = (e) => {
@@ -308,6 +307,7 @@ export default function ReportBugButton() {
 
             {/* Panel */}
             <motion.form
+              ref={formRef}
               onSubmit={submit}
               initial={{ opacity: 0, y: 40, scale: 0.98 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}

--- a/client/src/hooks/useFocusTrap.js
+++ b/client/src/hooks/useFocusTrap.js
@@ -1,0 +1,103 @@
+// src/hooks/useFocusTrap.js
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "iframe",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+function getFocusableElements(container) {
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (el) => el.getClientRects().length > 0,
+  );
+}
+
+/**
+ * Traps keyboard focus inside `containerRef` while `active` is true.
+ *
+ * - On activation, moves focus to `options.initialFocusRef` (or the first
+ *   focusable element) and remembers the previously focused element.
+ * - Cycles Tab / Shift+Tab through the focusable elements so focus can
+ *   never leave the container, pulling focus back in if it ever escapes.
+ * - Calls `options.onEscape` when Escape is pressed so the dialog can close.
+ * - On deactivation, restores focus to the previously focused element
+ *   (unless `options.restoreFocus` is false).
+ *
+ * Options are read through a ref so inline callbacks do not cause the
+ * listener to be re-bound (and focus to be re-stolen) on every render.
+ */
+export default function useFocusTrap(containerRef, active, options = {}) {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !active) return undefined;
+
+    const { initialFocusRef, onEscape, restoreFocus = true } = optionsRef.current;
+    const previouslyFocused = document.activeElement;
+
+    // Move focus into the dialog: the requested element, else the first
+    // focusable one (typically the close button).
+    const initialTarget = initialFocusRef?.current || getFocusableElements(container)[0];
+    initialTarget?.focus?.();
+
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        const { onEscape: escapeHandler } = optionsRef.current;
+        if (escapeHandler) {
+          e.preventDefault();
+          escapeHandler();
+        }
+        return;
+      }
+
+      if (e.key !== "Tab") return;
+
+      const focusable = getFocusableElements(container);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        return;
+      }
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement;
+
+      // Focus somehow landed outside the container: pull it back in.
+      if (!container.contains(activeEl)) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+        return;
+      }
+
+      if (e.shiftKey && activeEl === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && activeEl === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      const { restoreFocus: shouldRestore = true } = optionsRef.current;
+      if (
+        shouldRestore &&
+        previouslyFocused &&
+        typeof previouslyFocused.focus === "function" &&
+        document.contains(previouslyFocused)
+      ) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [containerRef, active]);
+}

--- a/client/src/pages/AdminInventory.jsx
+++ b/client/src/pages/AdminInventory.jsx
@@ -1,8 +1,9 @@
 // src/pages/AdminInventory.jsx
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import AdminNavbar from "../components/AdminNavbar";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import useFocusTrap from "../hooks/useFocusTrap";
 
 const LOW_STOCK_THRESHOLD = 5;
 const API_BASE = `${import.meta.env.VITE_API_URL}/api`;
@@ -101,11 +102,23 @@ const InventoryMobileCard = ({ p, onEdit }) => {
 
 // Simple modal component
 const Modal = ({ open, onClose, children }) => {
+  const modalRef = useRef(null);
+  // Trap keyboard focus inside the modal while open: Tab/Shift+Tab cycle
+  // within the panel, Escape closes it, focus moves to the close button
+  // on open and returns to the trigger on close.
+  useFocusTrap(modalRef, open, { onEscape: onClose });
+
   if (!open) return null;
   return (
     <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-6 sm:pb-0">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
-      <div className="relative bg-white rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-2xl mx-4 shadow-lg max-h-[90vh] overflow-auto">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} aria-hidden="true" />
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Edit product"
+        className="relative bg-white rounded-t-2xl sm:rounded-2xl p-6 w-full max-w-2xl mx-4 shadow-lg max-h-[90vh] overflow-auto"
+      >
         {children}
       </div>
     </div>

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import { auth } from "../auth/firebase";
 import { onAuthStateChanged } from "firebase/auth";
 import { getAuthHeaders } from "../utils/getAuthHeaders";
+import useFocusTrap from "../hooks/useFocusTrap";
 import {
   getRewardTier,
   getTierProgress,
@@ -125,6 +126,14 @@ export default function Profile() {
   const [editingAddress, setEditingAddress] = useState(null);
   const [activeTab, setActiveTab] = useState("profile");
   const fileInputRef = useRef();
+  const addressModalRef = useRef(null);
+
+  // Trap keyboard focus inside the address modal while open: Tab/Shift+Tab
+  // cycle within the panel, Escape closes it, focus moves to the close button
+  // on open and returns to the trigger on close.
+  useFocusTrap(addressModalRef, !!editingAddress, {
+    onEscape: () => setEditingAddress(null),
+  });
   const [photoURL, setPhotoURL] = useState(null);
   const [orders, setOrders] = useState([]);
   const [loadingOrders, setLoadingOrders] = useState(false);
@@ -597,8 +606,16 @@ const [rewardsError, setRewardsError] = useState("");
       {/* ── ADDRESS MODAL ── */}
       {editingAddress && (
         <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
-          <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setEditingAddress(null)} />
           <div
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+            onClick={() => setEditingAddress(null)}
+            aria-hidden="true"
+          />
+          <div
+            ref={addressModalRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Edit address"
             style={{ fontFamily: "'DM Sans', sans-serif" }}
             className="bg-white w-full sm:max-w-lg rounded-t-3xl sm:rounded-2xl p-6 z-50 max-h-[90vh] overflow-y-auto"
           >


### PR DESCRIPTION
Closes #961

## Summary

Adds a reusable `useFocusTrap` hook and applies it to the CartDrawer and every modal in the app, so keyboard users can no longer Tab out of an open dialog onto the blurred background content (Navbar, product grid, etc.). This closes a WCAG keyboard-navigation gap and makes the whole app keyboard-safe.

## Changes

**`client/src/hooks/useFocusTrap.js` (NEW)** — a small, dependency-free hook that:
- Moves focus to the requested initial element (or the first focusable) when the dialog opens
- Cycles Tab / Shift+Tab through the dialog's focusable elements, pulling focus back in if it ever escapes
- Closes on Escape via `onEscape`
- Restores focus to the previously focused element when the dialog closes
- Reads options through a ref so inline callbacks don't cause the listener to rebind (and re-steal focus) on every render

**`CartDrawer.jsx`** — replaced the hand-rolled trap with the shared hook. The old trap had an escape bug: when focus was outside the drawer, `indexOf(document.activeElement)` returned `-1`, so a forward Tab was never intercepted and focus could walk onto the blurred page. The closed drawer is now `inert`, so its buttons are no longer tabbable off-screen.

**`FitnessChatBot.jsx`** — focus is trapped in the chat window while open and moves to the message input immediately (replacing the 200ms delayed focus effect and the Escape-only keydown handler).

**`ReportBugButton.jsx`, `NearbyFitnessCenters.jsx`, `AdminInventory.jsx`, `Profile.jsx`** — focus traps on the bug report, fitness center detail, edit product, and address modals, plus `role="dialog"` and `aria-modal="true"` where they were missing.

## Validation
- `vite build` passes (only the pre-existing chunk-size warning)
- All changed files reviewed for hook ordering, React 19 strict-mode safety, and no regressions to existing close/escape behavior