### PR TITLE
build: sync server package-lock.json to fix npm ci in CI

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6294,6 +6294,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mongodb-memory-server-core/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/mongodb-memory-server-core/node_modules/mongodb": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
@@ -6361,6 +6378,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {


### PR DESCRIPTION
## Summary

Fixes the recurring **CI / Backend — tests** failure that shows up on every PR: `npm ci` errors with `Missing: gcp-metadata@7.0.1 from lock file`. It is unrelated to any PR's changes and happens on a clean checkout of `main`.

## Root cause

The lockfile's `mongodb@7.x` entries (nested under `mongodb-memory-server-core` and `mongoose`) declare an **optional peer dependency** on `gcp-metadata@^7.0.1`, but the lockfile had no entry for a 7.x version of `gcp-metadata` (only 6.1.1 and 8.1.2 existed). `npm ci` refuses to run when a peer dependency listed in the lockfile has no matching lock entry.

## Fix

Run `npm install` in `server/` to regenerate the lockfile. The only change is **`server/package-lock.json` (+33 lines)**: the missing nested `gcp-metadata@7.0.1` entries were added. `package.json` is untouched.

## Verification

- `npm ci` now succeeds in `server/` (previously failed with EUSAGE)
- All 78 backend tests pass (`jest`, 3 suites)