### PR TITLE
feat(navbar): add active visual states to routing links

### DIFF
--- a/client/src/components/AdminNavbar.jsx
+++ b/client/src/components/AdminNavbar.jsx
@@ -1,5 +1,5 @@
 // src/components/AdminNavbar.jsx
-import { useNavigate } from "react-router-dom";
+import { useNavigate, NavLink } from "react-router-dom";
 import { signOut } from "firebase/auth";
 import { auth } from "../auth/firebase";
 import { useAuth } from "../auth/useAuth";
@@ -74,16 +74,15 @@ export default function AdminNavbar({ range, setRange, menuOpen, setMenuOpen }) 
               ))}
             </div>
           ) : (
-            <button
-              onClick={() => navigate("/admin/dashboard")}
-              className="border border-stone-200 text-stone-600 text-xs px-3 sm:px-5
-                         py-2 rounded-full hover:bg-stone-900 hover:text-white
-                         hover:border-stone-900 transition-all cursor-pointer
-                         min-h-9 shrink-0"
+            <NavLink
+              to="/admin/dashboard"
+              className={({ isActive }) => 
+                `flex items-center justify-center border border-stone-200 text-xs px-3 sm:px-5 py-2 rounded-full hover:bg-stone-900 hover:text-white hover:border-stone-900 transition-all cursor-pointer min-h-9 shrink-0 ${isActive ? "font-semibold text-stone-900" : "text-stone-500"}`
+              }
             >
               <span className="hidden sm:inline">← Go to Dashboard</span>
               <span className="sm:hidden">← Dashboard</span>
-            </button>
+            </NavLink>
           )}
 
           {/* ── Profile dropdown ── */}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate, useLocation } from "react-router-dom";
+import { useNavigate, useLocation, NavLink } from "react-router-dom";
 import { signOut } from "firebase/auth";
 import { auth } from "../auth/firebase";
 import { useAuth } from "../auth/useAuth";
@@ -179,19 +179,19 @@ export default function Navbar({
 
                         {isLimitedNavRoute ? (
                           <div className="border-t border-stone-100 mt-1">
-                            <button role="menuitem" onClick={() => { navigate('/profile'); if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className="w-full text-left text-xs text-stone-700 hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">View Profile</button>
+                            <NavLink to="/profile" role="menuitem" onClick={() => { if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className={({ isActive }) => `block w-full text-left text-xs hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9 ${isActive ? 'font-semibold text-stone-900' : 'text-stone-500'}`}>View Profile</NavLink>
                             <button role="menuitem" onClick={handleSignOut} className="w-full text-left text-xs text-stone-500 hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">Sign Out</button>
                           </div>
                         ) : (
                           <>
                             {isLanding && (
-                              <button role="menuitem" onClick={() => { navigate('/home'); if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className="w-full text-left text-xs text-stone-700 font-medium hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">Go to Shop →</button>
+                              <NavLink to="/home" role="menuitem" onClick={() => { if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className={({ isActive }) => `block w-full text-left text-xs hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9 ${isActive ? 'font-semibold text-stone-900' : 'text-stone-500'}`}>Go to Shop →</NavLink>
                             )}
 
-                            <button role="menuitem" onClick={() => { navigate('/tracker'); if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className="w-full text-left text-xs text-stone-700 font-medium hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">Track Fitness →</button>
+                            <NavLink to="/tracker" role="menuitem" onClick={() => { if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className={({ isActive }) => `block w-full text-left text-xs hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9 ${isActive ? 'font-semibold text-stone-900' : 'text-stone-500'}`}>Track Fitness →</NavLink>
 
                             <div className="border-t border-stone-100 mt-1">
-                              <button role="menuitem" onClick={() => { navigate('/profile'); if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className="w-full text-left text-xs text-stone-700 hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">View Profile</button>
+                              <NavLink to="/profile" role="menuitem" onClick={() => { if (typeof setMenuOpen === 'function') setMenuOpen(false); else setLocalMenuOpen(false); }} className={({ isActive }) => `block w-full text-left text-xs hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9 ${isActive ? 'font-semibold text-stone-900' : 'text-stone-500'}`}>View Profile</NavLink>
                               <button role="menuitem" onClick={handleSignOut} className="w-full text-left text-xs text-stone-500 hover:bg-stone-50 px-4 py-2.5 transition-colors min-h-9">Sign Out</button>
                             </div>
                           </>


### PR DESCRIPTION
## 📋 What does this PR do?
Replaces standard `<button>` and `<a>` elements with React Router's `<NavLink>` component in `Navbar.jsx` and `AdminNavbar.jsx`. This dynamically applies active visual states (`font-semibold` and `text-stone-900`) based on the user's current route to improve UX and navigation clarity, while keeping inactive links lighter (`text-stone-500`).

## 🔗 Related Issue
Closes #966 

## 🧪 How was this tested?
- Replaced standard navigation components with `<NavLink>` in `Navbar.jsx` and `AdminNavbar.jsx`.
- Validated styling dynamically switches active routes to `font-semibold text-stone-900` and inactive to `text-stone-500`.
- Verified that styling strictly adheres to the project's existing `stone-*` Tailwind palette.
- Ran a local production build (`npx vite build`) which completed with 0 errors.

## ✅ Checklist
- [x] I've read the CONTRIBUTING guide
- [x] My code follows the project's style guidelines
- [x] I've tested my changes locally
- [x] I've linked the related issue
- [x] I haven't introduced any new secrets or API keys
