### PR TITLE
chore: add automatic comment for closed pull requests

### DIFF
--- a/.github/workflows/comment-on-pr-close.yml
+++ b/.github/workflows/comment-on-pr-close.yml
@@ -1,0 +1,36 @@
+name: Comment on Closed Pull Requests
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment on closed PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: `Hey @${prAuthor}👋
+
+Thank you for taking the time to contribute to FitMart!
+
+We are currently moving in a new direction with the project, so we are closing this pull request.
+
+Please check out the latest issues in the repository and feel free to contribute to those. We would love to see your contributions there!
+
+Thank you for your contribution and support.`
+            });


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions workflow that automatically comments on pull requests when they are closed.

The workflow:

* Detects when a pull request is closed.
* Automatically identifies the PR author.
* Posts a message thanking them for their contribution.
* Informs them that FitMart is moving in a new direction.
* Encourages contributors to check the latest open issues and contribute to them.

## Why?

FitMart currently has multiple older pull requests that need to be closed as the project moves in a new direction. Instead of manually commenting on every PR, this workflow automates the process and ensures that every contributor receives a consistent message.