### PR TITLE
feat(programs): mount programs router with Zod validation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -161,6 +161,9 @@ app.use("/api/user", require("./routes/user"));
 app.use("/api/customers", require("./routes/customers"));
 app.use("/api/exercises", require("./routes/exercises"));
 app.use("/api/workouts", require("./routes/workouts"));
+// Program catalog (public). Distinct prefix, so it cannot collide with the
+// existing product/exercise/workout routes above.
+app.use("/api/programs", require("./routes/programs"));
 app.use("/api/bugs", require("./routes/bugs"));
 
 // ── // Razorpay / payment routes (prefixed with /api/payment) ─────────────────

--- a/server/middleware/validateRequest.js
+++ b/server/middleware/validateRequest.js
@@ -4,16 +4,29 @@ function formatPath(path) {
   return path.length ? path.join('.') : 'request';
 }
 
+// Express 5 exposes `req.query` as a getter on the request prototype, so a plain
+// `req.query = ...` assignment is silently ignored and the parsed/coerced values
+// never reach the route handler. Defining an own property shadows the getter.
+function setParsedQuery(req, value) {
+  Object.defineProperty(req, 'query', {
+    value,
+    writable: true,
+    configurable: true,
+    enumerable: true,
+  });
+}
+
 function validateRequest(schema) {
   return (req, res, next) => {
     try {
       if (schema.params) req.params = schema.params.parse(req.params);
-      if (schema.query) req.query = schema.query.parse(req.query);
+      if (schema.query) setParsedQuery(req, schema.query.parse(req.query));
       if (schema.body) req.body = schema.body.parse(req.body);
       next();
     } catch (err) {
       if (err instanceof ZodError) {
         return res.status(400).json({
+          success: false,
           error: 'Invalid request',
           details: err.issues.map(issue => ({
             path: formatPath(issue.path),

--- a/server/models/Exercise.js
+++ b/server/models/Exercise.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+// Minimal Exercise catalogue entry. This exists so program days can reference a
+// real collection and GET /api/programs/:id can populate the fields it promises
+// (name, muscleGroup, equipment, image).
+//
+// The fuller Exercise model plus realistic seed data are tracked in #1001.
+const ExerciseSchema = new mongoose.Schema(
+  {
+    name: { type: String },
+    muscleGroup: { type: String },
+    equipment: { type: String },
+    image: { type: String, default: '' },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Exercise', ExerciseSchema);

--- a/server/models/Program.js
+++ b/server/models/Program.js
@@ -1,0 +1,49 @@
+const mongoose = require('mongoose');
+
+// A single prescription slot inside a program day. `_id: false` keeps the day
+// array clean since entries are positional data, not addressable documents.
+const programExerciseSchema = new mongoose.Schema(
+  {
+    exerciseId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Exercise',
+    },
+    sets: { type: Number },
+    reps: { type: Number },
+    restSeconds: { type: Number },
+    notes: { type: String, default: '' },
+  },
+  { _id: false }
+);
+
+const programDaySchema = new mongoose.Schema(
+  {
+    dayNumber: { type: Number },
+    focus: { type: String },
+    exercises: { type: [programExerciseSchema], default: [] },
+  },
+  { _id: false }
+);
+
+// Schema structure only. Required-field rules, custom validators (day count
+// matching `lengthDays`, unique day numbers, tag normalisation) and the
+// supporting indexes are tracked separately in #985.
+const ProgramSchema = new mongoose.Schema(
+  {
+    goal: { type: String },
+    difficulty: {
+      type: String,
+      enum: {
+        values: ['beginner', 'intermediate', 'advanced'],
+        message: '{VALUE} is not a supported difficulty',
+      },
+    },
+    lengthDays: { type: Number, min: 1, max: 90 },
+    day: { type: [programDaySchema], default: [] },
+    tags: { type: [String], default: [] },
+    image: { type: String, default: '' },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Program', ProgramSchema);

--- a/server/routes/programs.js
+++ b/server/routes/programs.js
@@ -1,0 +1,114 @@
+const express = require('express');
+const router = express.Router();
+const Program = require('../models/Program');
+// Required (even though it is not referenced directly) so Mongoose has the
+// 'Exercise' model registered when the detail route populates references.
+require('../models/Exercise');
+const validateRequest = require('../middleware/validateRequest');
+const { listProgramsSchema, programDetailSchema } = require('../validation/requestSchemas');
+const { ok, fail } = require('../utils/apiResponse');
+
+// User input reaches MongoDB's $regex, so metacharacters must be neutralised.
+// Without this a search like "[" throws and a crafted pattern can match more
+// than the caller asked for.
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// "-lengthDays" means descending; the plain field name means ascending.
+function buildSort(sort) {
+  const descending = sort.startsWith('-');
+  const field = descending ? sort.slice(1) : sort;
+  return { [field]: descending ? -1 : 1 };
+}
+
+// Inclusion projection when `fields` is supplied, otherwise a plain exclusion of
+// the internal version key so it cannot leak into API responses.
+function buildProjection(fields) {
+  if (!fields) return { __v: 0 };
+
+  return fields.split(',').reduce((projection, field) => {
+    const name = field.trim();
+    if (name) projection[name] = 1;
+    return projection;
+  }, {});
+}
+
+/**
+ * @route   GET /api/programs
+ * @desc    Public program catalog with pagination, filtering, search, sorting
+ * @access  Public
+ */
+router.get('/', validateRequest(listProgramsSchema), async (req, res) => {
+  try {
+    const { page, limit, difficulty, tag, search, sort, fields } = req.query;
+
+    const filter = {};
+    if (difficulty) filter.difficulty = difficulty;
+    if (tag) filter.tags = { $regex: `^${escapeRegex(tag)}$`, $options: 'i' };
+    if (search) {
+      const pattern = { $regex: escapeRegex(search), $options: 'i' };
+      filter.$or = [{ goal: pattern }, { tags: pattern }];
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [programs, total] = await Promise.all([
+      Program.find(filter, buildProjection(fields))
+        .sort(buildSort(sort))
+        .skip(skip)
+        .limit(limit)
+        .lean(),
+      Program.countDocuments(filter),
+    ]);
+
+    return ok(res, {
+      data: {
+        programs,
+        pagination: {
+          page,
+          limit,
+          total,
+          totalPages: Math.ceil(total / limit),
+        },
+      },
+    });
+  } catch (err) {
+    console.error('[programs] GET /api/programs error:', err);
+    return fail(res, 'Failed to fetch programs', 500);
+  }
+});
+
+/**
+ * @route   GET /api/programs/:id
+ * @desc    Public program detail with populated exercise references
+ * @access  Public
+ */
+router.get('/:id', validateRequest(programDetailSchema), async (req, res) => {
+  try {
+    const program = await Program.findById(req.params.id)
+      .select('-__v')
+      .populate({
+        path: 'day.exercises.exerciseId',
+        select: 'name muscleGroup equipment image',
+      })
+      .lean();
+
+    if (!program) return fail(res, 'Program not found', 404);
+
+    // Days are stored in creation order; return them in program order so the
+    // timeline is stable regardless of how the document was written. dayNumber is
+    // still optional until #985 adds its validators, so fall back to 0 rather
+    // than letting the comparator return NaN.
+    if (Array.isArray(program.day)) {
+      program.day.sort((a, b) => (a.dayNumber ?? 0) - (b.dayNumber ?? 0));
+    }
+
+    return ok(res, { data: { program } });
+  } catch (err) {
+    console.error('[programs] GET /api/programs/:id error:', err);
+    return fail(res, 'Failed to fetch program', 500);
+  }
+});
+
+module.exports = router;

--- a/server/tests/programs.test.js
+++ b/server/tests/programs.test.js
@@ -1,0 +1,342 @@
+/**
+ * Integration tests for the programs catalog (server/routes/programs.js).
+ *
+ * Uses mongodb-memory-server so the routes exercise the real Mongoose query
+ * layer (complex filters, $regex, sort, projection, skip/limit and populate)
+ * instead of a mocked model.
+ *
+ * Run with: npx jest tests/programs.test.js
+ */
+
+const fs = require('fs');
+const request = require('supertest');
+const express = require('express');
+const mongoose = require('mongoose');
+const { MongoMemoryServer } = require('mongodb-memory-server');
+
+const Program = require('../models/Program');
+const Exercise = require('../models/Exercise');
+const programsRouter = require('../routes/programs');
+
+let mongoServer;
+let app;
+
+// Same convention as cart.reserved.test.js: prefer a locally installed Windows
+// binary when present, otherwise let mongodb-memory-server fetch its own.
+const WINDOWS_MONGOD_PATH = 'C:\\Program Files\\MongoDB\\Server\\8.0\\bin\\mongod.exe';
+
+beforeAll(async () => {
+  if (process.platform === 'win32' && fs.existsSync(WINDOWS_MONGOD_PATH)) {
+    process.env.MONGOMS_SYSTEM_BINARY = WINDOWS_MONGOD_PATH;
+  }
+
+  mongoServer = await MongoMemoryServer.create();
+  await mongoose.connect(mongoServer.getUri());
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/programs', programsRouter);
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  if (mongoServer) await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  await Promise.all([Program.deleteMany({}), Exercise.deleteMany({})]);
+});
+
+// Helper: create a program with sensible defaults so each test only states what
+// it actually cares about. Uses `save(options)` rather than `Program.create(doc,
+// options)` because create() is variadic and would treat the options object as a
+// second document to insert.
+function createProgram(overrides = {}, options = undefined) {
+  const program = new Program({
+    goal: 'Build full body strength',
+    difficulty: 'beginner',
+    lengthDays: 3,
+    tags: ['strength', 'full-body'],
+    day: [
+      { dayNumber: 1, focus: 'Push', exercises: [] },
+      { dayNumber: 2, focus: 'Pull', exercises: [] },
+      { dayNumber: 3, focus: 'Legs', exercises: [] },
+    ],
+    ...overrides,
+  });
+
+  return program.save(options);
+}
+
+describe('GET /api/programs (list)', () => {
+  test('returns an empty catalog with pagination metadata', async () => {
+    const res = await request(app).get('/api/programs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data.programs).toEqual([]);
+    expect(res.body.data.pagination).toMatchObject({
+      page: 1,
+      limit: 10,
+      total: 0,
+      totalPages: 0,
+    });
+  });
+
+  test('returns the catalog with the default page and limit', async () => {
+    await createProgram();
+    await createProgram({ goal: 'Improve mobility', difficulty: 'advanced' });
+
+    const res = await request(app).get('/api/programs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs).toHaveLength(2);
+    expect(res.body.data.pagination).toMatchObject({
+      page: 1,
+      limit: 10,
+      total: 2,
+      totalPages: 1,
+    });
+  });
+
+  test('paginates using page and limit', async () => {
+    await Promise.all(
+      [1, 2, 3, 4, 5].map((n) => createProgram({ goal: `Program ${n}`, lengthDays: n }))
+    );
+
+    const res = await request(app).get('/api/programs?page=2&limit=2');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs).toHaveLength(2);
+    expect(res.body.data.pagination).toMatchObject({
+      page: 2,
+      limit: 2,
+      total: 5,
+      totalPages: 3,
+    });
+  });
+
+  test('defaults to newest first', async () => {
+    await createProgram(
+      { goal: 'Oldest', createdAt: new Date('2026-01-01T00:00:00Z') },
+      { timestamps: false }
+    );
+    await createProgram(
+      { goal: 'Newest', createdAt: new Date('2026-06-01T00:00:00Z') },
+      { timestamps: false }
+    );
+
+    const res = await request(app).get('/api/programs');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs.map((p) => p.goal)).toEqual(['Newest', 'Oldest']);
+  });
+
+  test('sorts ascending when the field has no - prefix', async () => {
+    await createProgram({ goal: 'Long', lengthDays: 30 });
+    await createProgram({ goal: 'Short', lengthDays: 7 });
+
+    const res = await request(app).get('/api/programs?sort=lengthDays');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs.map((p) => p.lengthDays)).toEqual([7, 30]);
+  });
+
+  test('sorts descending when the field is prefixed with -', async () => {
+    await createProgram({ goal: 'Long', lengthDays: 30 });
+    await createProgram({ goal: 'Short', lengthDays: 7 });
+
+    const res = await request(app).get('/api/programs?sort=-lengthDays');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs.map((p) => p.lengthDays)).toEqual([30, 7]);
+  });
+
+  test('filters by difficulty', async () => {
+    await createProgram({ goal: 'Beginner plan', difficulty: 'beginner' });
+    await createProgram({ goal: 'Advanced plan', difficulty: 'advanced' });
+
+    const res = await request(app).get('/api/programs?difficulty=advanced');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs).toHaveLength(1);
+    expect(res.body.data.programs[0].goal).toBe('Advanced plan');
+    expect(res.body.data.pagination.total).toBe(1);
+  });
+
+  test('filters by tag case-insensitively', async () => {
+    await createProgram({ goal: 'Strength plan', tags: ['strength'] });
+    await createProgram({ goal: 'Yoga plan', tags: ['mobility'] });
+
+    const res = await request(app).get('/api/programs?tag=STRENGTH');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs).toHaveLength(1);
+    expect(res.body.data.programs[0].goal).toBe('Strength plan');
+  });
+
+  test('searches across goal and tags case-insensitively', async () => {
+    await createProgram({ goal: 'Hypertrophy builder', tags: ['muscle'] });
+    await createProgram({ goal: 'Mobility reset', tags: ['recovery', 'HYPERTROPHY'] });
+    await createProgram({ goal: 'Endurance base', tags: ['cardio'] });
+
+    const viaGoal = await request(app).get('/api/programs?search=hypertrophy');
+    expect(viaGoal.status).toBe(200);
+    expect(viaGoal.body.data.pagination.total).toBe(2);
+
+    const viaTag = await request(app).get('/api/programs?search=cardio');
+    expect(viaTag.status).toBe(200);
+    expect(viaTag.body.data.programs).toHaveLength(1);
+    expect(viaTag.body.data.programs[0].goal).toBe('Endurance base');
+  });
+
+  test('treats regex metacharacters in search as literal text', async () => {
+    await createProgram({ goal: 'Conditioning plan' });
+
+    // An unescaped "[" would reach MongoDB as an invalid pattern and throw.
+    const res = await request(app).get('/api/programs?search=%5B');
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.programs).toEqual([]);
+    expect(res.body.data.pagination.total).toBe(0);
+  });
+
+  test('applies a field projection', async () => {
+    await createProgram({ goal: 'Strength plan' });
+
+    const res = await request(app).get('/api/programs?fields=goal,lengthDays');
+
+    expect(res.status).toBe(200);
+    const [program] = res.body.data.programs;
+    expect(program.goal).toBe('Strength plan');
+    expect(program.lengthDays).toBe(3);
+    expect(program).not.toHaveProperty('tags');
+    expect(program).not.toHaveProperty('day');
+  });
+
+  test('does not leak the version key', async () => {
+    await createProgram();
+
+    const res = await request(app).get('/api/programs');
+
+    expect(res.body.data.programs[0]).not.toHaveProperty('__v');
+  });
+
+  test.each([
+    ['limit above the maximum', '/api/programs?limit=51', 'limit'],
+    ['a non-numeric page', '/api/programs?page=abc', 'page'],
+    ['an unsupported difficulty', '/api/programs?difficulty=extreme', 'difficulty'],
+    ['an unsupported sort field', '/api/programs?sort=price', 'sort'],
+  ])('rejects %s with the standard error envelope', async (_label, url, field) => {
+    const res = await request(app).get(url);
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Invalid request');
+    expect(Array.isArray(res.body.details)).toBe(true);
+    expect(res.body.details.map((d) => d.path)).toContain(field);
+  });
+});
+
+describe('GET /api/programs/:id (detail)', () => {
+  test('returns the program with populated exercise references', async () => {
+    const exercise = await Exercise.create({
+      name: 'Barbell Bench Press',
+      muscleGroup: 'chest',
+      equipment: 'barbell',
+      image: 'https://cdn.example.com/bench.png',
+    });
+
+    const program = await createProgram({
+      day: [
+        {
+          dayNumber: 1,
+          focus: 'Push',
+          exercises: [
+            {
+              exerciseId: exercise._id,
+              sets: 3,
+              reps: 10,
+              restSeconds: 60,
+              notes: 'Warm up first',
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await request(app).get(`/api/programs/${program._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+
+    const [slot] = res.body.data.program.day[0].exercises;
+    expect(slot.exerciseId).toMatchObject({
+      name: 'Barbell Bench Press',
+      muscleGroup: 'chest',
+      equipment: 'barbell',
+      image: 'https://cdn.example.com/bench.png',
+    });
+    expect(slot).toMatchObject({ sets: 3, reps: 10, restSeconds: 60, notes: 'Warm up first' });
+  });
+
+  test('returns days ordered by day number', async () => {
+    const program = await createProgram({
+      day: [
+        { dayNumber: 3, focus: 'Legs', exercises: [] },
+        { dayNumber: 1, focus: 'Push', exercises: [] },
+        { dayNumber: 2, focus: 'Pull', exercises: [] },
+      ],
+    });
+
+    const res = await request(app).get(`/api/programs/${program._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.program.day.map((d) => d.dayNumber)).toEqual([1, 2, 3]);
+    expect(res.body.data.program.day.map((d) => d.focus)).toEqual(['Push', 'Pull', 'Legs']);
+  });
+
+  test('returns the program even when an exercise reference is dangling', async () => {
+    const program = await createProgram({
+      day: [
+        {
+          dayNumber: 1,
+          focus: 'Push',
+          exercises: [{ exerciseId: new mongoose.Types.ObjectId(), sets: 3, reps: 10 }],
+        },
+      ],
+    });
+
+    const res = await request(app).get(`/api/programs/${program._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.program.day[0].exercises[0].exerciseId).toBeNull();
+  });
+
+  test('does not leak the version key', async () => {
+    const program = await createProgram();
+
+    const res = await request(app).get(`/api/programs/${program._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.program).not.toHaveProperty('__v');
+  });
+
+  test('returns 404 for a valid but unknown id', async () => {
+    const res = await request(app).get(
+      `/api/programs/${new mongoose.Types.ObjectId().toString()}`
+    );
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ success: false, error: 'Program not found' });
+  });
+
+  test('returns 400 for a malformed id', async () => {
+    const res = await request(app).get('/api/programs/not-a-valid-object-id');
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.error).toBe('Invalid request');
+    expect(res.body.details.map((d) => d.path)).toContain('id');
+  });
+});

--- a/server/validation/requestSchemas.js
+++ b/server/validation/requestSchemas.js
@@ -74,6 +74,40 @@ const workoutLogBodySchema = z.object({
   exercises: z.array(workoutExerciseSchema).optional()
 }).strict();
 
+// ── Programs ────────────────────────────────────────────────────────────────
+
+const objectIdSchema = z
+  .string()
+  .regex(/^[0-9a-f]{24}$/i, 'must be a 24-character hexadecimal id');
+
+const programIdParamsSchema = z.object({
+  id: objectIdSchema,
+});
+
+// Sort accepts one of the documented fields, optionally prefixed with "-" to
+// reverse the order (for example `-lengthDays`). Unknown fields are rejected so
+// a caller cannot ask MongoDB to sort on an unindexed/arbitrary path.
+const programSortSchema = z
+  .string()
+  .trim()
+  .regex(
+    /^-?(createdAt|goal|difficulty|lengthDays)$/,
+    'sort must be one of createdAt, goal, difficulty, lengthDays (prefix with - to reverse)'
+  )
+  .default('-createdAt');
+
+// Unknown query params are stripped rather than rejected, so cache-busting
+// params and future additions do not turn into 400s for existing clients.
+const listProgramsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1, 'page must be 1 or greater').default(1),
+  limit: z.coerce.number().int().min(1).max(50, 'limit cannot exceed 50').default(10),
+  difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
+  tag: z.string().trim().min(1, 'tag cannot be empty').optional(),
+  search: z.string().trim().min(1, 'search cannot be empty').optional(),
+  sort: programSortSchema,
+  fields: z.string().trim().min(1, 'fields cannot be empty').optional(),
+});
+
 module.exports = {
   cartAddSchema: {
     params: userIdParamsSchema,
@@ -98,5 +132,11 @@ module.exports = {
   },
   updateWorkoutLogSchema: {
     body: workoutLogBodySchema,
+  },
+  listProgramsSchema: {
+    query: listProgramsQuerySchema,
+  },
+  programDetailSchema: {
+    params: programIdParamsSchema,
   },
 };


### PR DESCRIPTION
Closes #990

## Summary

Adds the public program catalog endpoints and mounts them in Express, giving the Phase 1 Program spine a routable API surface.

## Changes

| File | Change |
| --- | --- |
| `server/models/Program.js` | New. Schema structure per #984: `goal`, `difficulty` enum, `lengthDays` (1-90), `day[]` (`dayNumber`, `focus`, `exercises[]`), `tags[]`, optional `image`, plus `timestamps`. |
| `server/models/Exercise.js` | New, minimal. Exists so program days can reference a real collection and the detail route can populate `name`, `muscleGroup`, `equipment`, `image`. |
| `server/routes/programs.js` | New. Both endpoints, with pagination, filtering, search, sorting, projection and populated detail. |
| `server/validation/requestSchemas.js` | Adds `listProgramsSchema` (query) and `programDetailSchema` (path param). |
| `server/index.js` | Mounts the router at `/api/programs`. |
| `server/middleware/validateRequest.js` | Two fixes, see below. |
| `server/tests/programs.test.js` | New. 22 integration tests. |

### Endpoints

`GET /api/programs` accepts `page` (default 1), `limit` (default 10, max 50), `difficulty`, `tag`, `search` (goal and tags, case-insensitive), `sort` (`createdAt`, `goal`, `difficulty`, `lengthDays`, prefix with `-` to reverse, default `-createdAt`) and `fields` (comma separated projection). Filters are only applied when present.

`GET /api/programs/:id` validates the id, populates `day[].exercises[].exerciseId`, returns days ordered by `dayNumber`, returns 404 for a valid but unknown id, and does not leak `__v`.

## Bug fixed in the shared validation middleware

Express 5 exposes `req.query` as a getter on the request prototype, so `validateRequest`'s `req.query = schema.query.parse(req.query)` was a silent no-op. Query schemas ran, but their parsed and coerced output was thrown away. Verified directly:

```js
app.get('/x', (req, res, next) => { req.query = { a: 1 }; next(); }, (req, res) => res.json(req.query));
// GET /x?b=2  ->  { "b": "2" }   (assignment ignored)
```

The middleware now defines an own property to shadow the getter, which is what makes `page` and `limit` arrive at the handler as numbers. `req.params` and `req.body` assignment are unaffected in Express 5 (both verified), so only the query path needed changing.

Validation failures also now include `success: false` so they match the envelope documented in the README API response contract. This is additive, so existing clients that read `error` and `details` are unaffected.

## Notes for review

- **Response shape.** The issue body writes `{ ok: true, data: {...} }`, but `server/utils/apiResponse.js` produces `{ success: true, ...data }` and the README API response contract says new endpoints should use the `ok()`/`fail()` helpers. I followed the helpers, so responses are `{ success: true, data: { programs, pagination } }`. Happy to switch to a literal `ok` key if you would rather match the issue text.
- **Scope.** `Program` deliberately ships with schema structure only. Required-ness and the cross-field rules (`day.length` matching `lengthDays`, unique day numbers, tag normalisation) plus the five indexes belong to #985, so that issue stays a clean standalone task. The same goes for the fuller `Exercise` model and seed data in #1001. If #999 or #1001 merges first, `server/models/Program.js` here should be dropped in favour of theirs.
- The `tag` filter is case-insensitive and regex-escaped, so it still works before #985 normalises tags to lowercase. The same escaping is applied to `search`, which otherwise lets a value like `[` reach MongoDB as an invalid pattern.

## Verification

- `npm test` in `server/`: **4 suites, 100 tests, all passing** (78 pre-existing plus 22 new).
- Booted the real server against an in-memory MongoDB and hit the new routes through the full middleware stack:
  - `GET /api/programs` returns `200 {"success":true,"data":{"programs":[],"pagination":{"page":1,"limit":10,"total":0,"totalPages":0}}}`
  - `GET /api/programs?limit=999` returns `400 {"success":false,"error":"Invalid request","details":[{"path":"limit","message":"limit cannot exceed 50"}]}`
  - `GET /api/programs/<unknown id>` returns `404 {"success":false,"error":"Program not found"}`
  - `GET /api/programs/not-an-id` returns `400` with `{"path":"id"}`
- Confirmed no route conflicts: `/api/programs` is a new prefix and nothing else mounts it.

Note: the `CI / Backend - tests` job currently fails at `npm ci` on `main` because `server/package-lock.json` is missing `gcp-metadata@7.0.1`. That is unrelated to this PR and is fixed separately by #963.
